### PR TITLE
Handle single value lines in text/csv

### DIFF
--- a/doc/reference/text.md
+++ b/doc/reference/text.md
@@ -250,25 +250,39 @@ Format one line of *fields* to *port* in CSV format, using the current syntax pa
 ``` scheme
 (write-csv-lines lines port) -> void
 
-  lines := list of strings
+  lines := list-of-lines or list-of-fields
   port  := output port
 ```
 
-Given a list of *lines*, each of them a list of fields, and a PORT,
+::: tip Examples
+``` scheme
+> (let (list-of-fields '("ID" 1 2 3))
+    (call-with-output-string []
+      (cut write-csv-lines  list-of-fields <>)))
+"ID\r\n1\r\n2\r\n3\r\n"
+
+> (let (list-of-lines '(("ID") (1) (2) (3)))
+    (call-with-output-string []
+      (cut write-csv-lines  list-of-lines <>)))
+"ID\r\n1\r\n2\r\n3\r\n"
+```
+:::
+
+Given a list of fields or a list of `lines`, each of them a list of fields, and a `port`,
 format those lines as CSV according to the current syntax parameters.
 
 ### write-csv-file
 ``` scheme
 (write-csv-file path lines . settings) -> void
 
-  lines    := list of strings
+  lines    := list-of-lines or list-of-fields
   path     := output path
   settings := optional path settings
 ```
-Writes `lines` to the designated `path` using `write-csv-lines`
+Writes list of `lines` or a list of fields to the designated `path` using `write-csv-lines`
 and the provided `settings`. Check section
 [17.7.1 Filesystem devices](http://www.iro.umontreal.ca/~gambit/doc/gambit.html#Filesystem-devices)
-of the Gambit Manual if you want to know more about the `settings` parameter.
+of the Gambit Manual if you want to learn more about the `settings` parameter.
 
 ::: tip Examples:
 ``` scheme

--- a/src/std/text/csv-test.ss
+++ b/src/std/text/csv-test.ss
@@ -71,7 +71,10 @@
        +lf+)
       (test-both
        ""
-       '()))
+       '())
+      (check
+        (call-with-output-string [] (cut write-csv-lines '("1" "2") <>))
+        => "1\r\n2\r\n"))
     (test-case "parameters"
       (def setters
         (hash (separator csv-options-separator-set!)

--- a/src/std/text/csv.ss
+++ b/src/std/text/csv.ss
@@ -310,13 +310,22 @@
            (string-any (cut w/opt char-needs-quoting? <>) x))
        #t))
 
-;; Given a list of LINES, each of them a list of fields, and a PORT,
-;; format those lines as CSV according to the current syntax parameters.
-(def/opt (write-csv-lines lines port)
-  (for-each (cut w/opt write-csv-line <> port) lines))
+;; Checks if the list is a list-of-lines (as understood by text/csv).
+;; The procedure returns #t for [[1] [2]], [[]], [], but not for [1 2].
+(def (list-of-lines? lst)
+  (or (null? lst)
+      (and (pair? lst)
+           (? (or pair? null?) (car lst)))))
 
-;; Writes list of LINES to the designated PATH using write-csv-lines
-;; and the provided settings.
+;; Given a list of fields or list of LINES, each of them a list of fields,
+;; and a PORT, format those lines as CSV according to the current
+;; syntax parameters.
+(def/opt (write-csv-lines lines port)
+  (for-each (cut w/opt write-csv-line <> port)
+            (if (list-of-lines? lines) lines (map list lines))))
+
+;; Writes list of LINES or a list of fields to the designated PATH using
+;; write-csv-lines and the provided settings.
 (def/opt (write-csv-file path-or-settings lines)
   (call-with-output-file path-or-settings
     (cut w/opt write-csv-lines lines <>)))


### PR DESCRIPTION
Adds support to write a _list-of-strings_ to a csv file. Previously `:std/text/csv` only had support for _lists-of-lists_.

Now `(write-csv-file "out.csv" ["1" "2"]` is the same as calling `(write-csv-file "out.csv" [["1"] ["2"]]`.