### PR TITLE
document make -j

### DIFF
--- a/doc/guide/README.md
+++ b/doc/guide/README.md
@@ -43,9 +43,10 @@ to the configure script (see below).
 After unpacking a release or checking out the source code from Github,
 cd into the `gerbil` directory.
 
-Gerbil takes quite a while to compile, if you wish it to build faster, you can:
+Gerbil takes quite a while to compile, if you wish it to build faster
+by utilizing multiple cores, you can:
 ```
-export GERBIL_BUILD_CORES=4
+make -j <number-of-cores>
 ```
 
 If you are using the default configuration, you can build Gerbil simply with:

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -61,9 +61,8 @@ configuring with the `CC=compiler` variable and setting the
 If you are having problems with your system's ar, you can also set the
 `GERBIL_AR` environment variable to point to a specific `ar` that works.
 
-Finally, Gerbil consults the `GERBIL_BUILD_CORES` environment variable
-to determine whether to build its code in parallel, e.g.
-`export GERBIL_BUILD_CORES=4` to build using 4 cores.
+Finally, the Gerbil Makefile honors the `-j` option; e.g.
+`make -j4` to build using 4 cores.
 
 If you want to enable standard library modules that are not built by
 default, you can do so by configuring with `./configure ... --enable-<feature> ...`.


### PR DESCRIPTION
Thanks to @leahneukirchen we can now just `make -j4` instead of having to set the build cores during the build.
This documents it.