### PR TITLE
CI: use all vm cores in github workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,47 +21,47 @@ jobs:
       - name: Prepare Build
         run: |
            . ./build-env.sh
-           ./src/build.sh prepare
+           GERBIL_BUILD_CORES=$(nproc) ./src/build.sh prepare
       - name: Build Gambit
         run: |
            . ./build-env.sh
-           ./src/build.sh gambit
+           GERBIL_BUILD_CORES=$(nproc) ./src/build.sh gambit
       - name: Build Gerbil boot gxi
         run: |
            . ./build-env.sh
-           ./src/build.sh boot-gxi
+           GERBIL_BUILD_CORES=$(nproc) ./src/build.sh boot-gxi
       - name: Build Gerbil stage0
         run: |
           . ./build-env.sh
-          ./src/build.sh stage0
+          GERBIL_BUILD_CORES=$(nproc) ./src/build.sh stage0
       - name: Build Gerbil stage1
         run: |
           . ./build-env.sh
-          ./src/build.sh stage1
+          GERBIL_BUILD_CORES=$(nproc) ./src/build.sh stage1
       - name: Build Gerbil stdlib
         run: |
           . ./build-env.sh
-          ./src/build.sh stdlib
+          GERBIL_BUILD_CORES=$(nproc) ./src/build.sh stdlib
       - name: Build Gerbil libgerbil
         run: |
           . ./build-env.sh
-          ./src/build.sh libgerbil
+          GERBIL_BUILD_CORES=$(nproc) ./src/build.sh libgerbil
       - name: Build Gerbil lang
         run: |
           . ./build-env.sh
-          ./src/build.sh lang
+          GERBIL_BUILD_CORES=$(nproc) ./src/build.sh lang
       - name: Build Gerbil r7rs-large
         run: |
           . ./build-env.sh
-          ./src/build.sh r7rs-large
+          GERBIL_BUILD_CORES=$(nproc) ./src/build.sh r7rs-large
       - name: Build Gerbil srfi shims
         run: |
           . ./build-env.sh
-          ./src/build.sh srfi
+          GERBIL_BUILD_CORES=$(nproc) ./src/build.sh srfi
       - name: Build Gerbil tools
         run: |
           . ./build-env.sh
-          ./src/build.sh tools
+          GERBIL_BUILD_CORES=$(nproc) ./src/build.sh tools
       - name: Install Gerbil
         run: ./install.sh
       - name: Run Gerbil tests

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,7 @@ RUN cd /opt && git clone https://github.com/vyzo/gerbil gerbil-src
 RUN cd /opt/gerbil-src && git fetch -a && git fetch --tags && git checkout ${gerbil_version} \
     && eval ./configure --prefix=/opt/gerbil ${configure_args}
 
-RUN cd /opt/gerbil-src && make && make install
+RUN cd /opt/gerbil-src && make -j ${GERBIL_BUILD_CORES} && make install
 
 FROM gerbil as final
 RUN rm -rf /opt/gerbil-src /src/leveldb /src/lmdb


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources