### PR TITLE
fix make -j passing build cores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,7 @@
-# Parse -j from MAKEFLAGS for parallelism.
-GERBIL_BUILD_CORES := $(or $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS))),1) 
-
 all: build
 
 build:
-	GERBIL_BUILD_CORES=$(GERBIL_BUILD_CORES) ./build.sh
+	GERBIL_BUILD_FLAGS="$(MAKEFLAGS)" ./build.sh
 
 install:
 	./install.sh

--- a/doc/guide/README.md
+++ b/doc/guide/README.md
@@ -46,7 +46,7 @@ cd into the `gerbil` directory.
 Gerbil takes quite a while to compile, if you wish it to build faster
 by utilizing multiple cores, you can:
 ```
-make -j <number-of-cores>
+make -j<number-of-cores>
 ```
 
 If you are using the default configuration, you can build Gerbil simply with:

--- a/doc/guide/README.md
+++ b/doc/guide/README.md
@@ -49,6 +49,10 @@ by utilizing multiple cores, you can:
 make -j<number-of-cores>
 ```
 
+Alternatively, you can set the `GERBIL_BUILD_CORES` environment
+variable to the number of cores you want to use.
+
+
 If you are using the default configuration, you can build Gerbil simply with:
 ```bash
 $ ./configure && make && sudo make install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,7 @@ RUN cd /opt && git clone https://github.com/vyzo/gerbil gerbil-src
 RUN cd /opt/gerbil-src && git fetch -a && git fetch --tags && git checkout ${gerbil_version} \
     && eval ./configure --prefix=/opt/gerbil --enable-shared=no ${configure_args}
 
-RUN cd /opt/gerbil-src && make -j ${GERBIL_BUILD_CORES} && make install
+RUN cd /opt/gerbil-src && make -j${GERBIL_BUILD_CORES} && make install
 
 FROM gerbil as final
 RUN rm -rf /opt/gerbil-src /src/leveldb /src/lmdb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,7 @@ RUN cd /opt && git clone https://github.com/vyzo/gerbil gerbil-src
 RUN cd /opt/gerbil-src && git fetch -a && git fetch --tags && git checkout ${gerbil_version} \
     && eval ./configure --prefix=/opt/gerbil --enable-shared=no ${configure_args}
 
-RUN cd /opt/gerbil-src && make -j${GERBIL_BUILD_CORES} && make install
+RUN cd /opt/gerbil-src && make && make install
 
 FROM gerbil as final
 RUN rm -rf /opt/gerbil-src /src/leveldb /src/lmdb

--- a/src/build.sh
+++ b/src/build.sh
@@ -6,6 +6,20 @@ cd $(dirname "$0") # Change to this directory
 # Assuming this script is run with: `cd $GERBIL_BASE/src && ./build.sh`
 #===============================================================================
 
+# utility to get number of cores from make -j
+build_flags_cores() {
+    for x in $1; do
+        case $x in
+            -j*)
+                echo $x | cut -d j -f 2
+                break
+                ;;
+            *)
+                ;;
+        esac
+    done
+}
+
 # Check for GERBIL_PREFIX being set
 # This is necessary for the bach build script to set the correct RUNPATH in the
 # gerbil binary.
@@ -41,6 +55,15 @@ else
     LD_LIBRARY_PATH="${GERBIL_BUILD_PREFIX}/lib:${LD_LIBRARY_PATH}"
 fi
 export LD_LIBRARY_PATH
+
+if [ "x${GERBIL_BUILD_FLAGS:-}" != "x" ];then
+    num_cores=$(build_flags_cores "${GERBIL_BUILD_FLAGS}")
+    if [ "x${num_cores:-}" != "x" ]; then
+        echo "using ${num_cores} cores for the build"
+        GERBIL_BUILD_CORES=${num_cores}
+        export GERBIL_BUILD_CORES
+    fi
+fi
 
 #===============================================================================
 ## feedback

--- a/src/build.sh
+++ b/src/build.sh
@@ -11,7 +11,7 @@ build_flags_cores() {
     for x in $1; do
         case $x in
             -j*)
-                echo $x | cut -d j -f 2
+                echo ${x##-j}
                 break
                 ;;
             *)

--- a/src/build.sh
+++ b/src/build.sh
@@ -56,13 +56,16 @@ else
 fi
 export LD_LIBRARY_PATH
 
-if [ "x${GERBIL_BUILD_FLAGS:-}" != "x" ];then
+if [ "x${GERBIL_BUILD_FLAGS:-}" != "x" ]; then
     num_cores=$(build_flags_cores "${GERBIL_BUILD_FLAGS}")
     if [ "x${num_cores:-}" != "x" ]; then
-        echo "using ${num_cores} cores for the build"
         GERBIL_BUILD_CORES=${num_cores}
         export GERBIL_BUILD_CORES
     fi
+fi
+
+if [ "x${GERBIL_BUILD_CORES:-}" != "x" ]; then
+    echo "using ${GERBIL_BUILD_CORES} cores for the build"
 fi
 
 #===============================================================================


### PR DESCRIPTION
The magic incantation in the Makefile doesn't work. This uses a hack to fix it, but also doesn't break the default user GERBIL_BUILD_CORES if no -j is passed, so a win overall.