### PR TITLE
Macros for exception context

### DIFF
--- a/src/gerbil/runtime/error.ss
+++ b/src/gerbil/runtime/error.ss
@@ -131,9 +131,15 @@ namespace: #f
 
 (defmethod {display-exception Error}
   (lambda (self port)
-    (let (tmp-port (open-output-string))
+    (let ((tmp-port (open-output-string))
+          (display-error-newline
+           (if (macro-character-port? port)
+             (> (macro-character-port-wchars port) 0)
+             #f)))
       (fix-port-width! tmp-port)
       (parameterize ((current-output-port tmp-port))
+        (when display-error-newline ; avoid clown shoes at the repl prompt
+          (newline))
         (display "*** ERROR IN ")
         (cond
          ((&Error-where self) => display)

--- a/src/gerbil/runtime/gambit.ss
+++ b/src/gerbil/runtime/gambit.ss
@@ -62,6 +62,7 @@ namespace: #f
   macro-readtable-brace-handler-set!
   macro-exception?
   macro-character-port?
+  macro-character-port-wchars
   macro-character-port-output-width
   macro-character-port-output-width-set!)
 

--- a/src/std/xml/_libxml.scm
+++ b/src/std/xml/_libxml.scm
@@ -404,7 +404,7 @@ END-C
    ((macro-character-input-port? port)
     (parse (read-char-port port) url encoding options))
    (else
-    (std/error#raise-unspecified-error "Can't parse port; not a byte or character input port" port))))
+    (error "Can't parse port; not a byte or character input port" port))))
 
 (define (xmlRead-port port url encoding options)
   (xmlRead-iocontext xmlRead-u8vector* port url encoding options))

--- a/src/std/xml/sxml-to-xml.scm
+++ b/src/std/xml/sxml-to-xml.scm
@@ -95,9 +95,6 @@
               next-separator
               ))
 
-(define-macro (error message . args)
-  `(std/error#raise-unspecified-error message ,@args))
-
 (define valid-quote-chars '(#\" #\'))
 
 ; The following regards HTML/XHTML though as XML is so frequently used, we include it here.


### PR DESCRIPTION
A couple of utility macros in `:std/error` to aid error raisers.
Also fixes clown shoes with double `*** ERROR` display in the repl.