### PR TITLE
Build Isolation and Manifests

### DIFF
--- a/doc/guide/env-vars.md
+++ b/doc/guide/env-vars.md
@@ -59,3 +59,10 @@ You can wholly disable parallelism by exporting `GERBIL_BUILD_CORES=0`,
 at which point the Gerbil part of compilation will be done in the current process.
 By contrast, `GERBIL_BUILD_CORES=1` enforces use of subprocesses for Gerbil compilation,
 even though only one process will be run at once.
+
+## GERBIL_PKG_GIT_USER
+
+If this variable is set, `gxpkg` will clone packages using `git` over
+ssh instead of https.
+
+Set this if you want to access private repose.

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -34,7 +34,7 @@ I usually configure Gerbil for devlopment with the following incantation:
 This will install Gerbil in `/usr/local/gerbil`; you should add
 `/usr/local/gerbil/bin` to your path.
 
-Note that this configuration enables share libraries: all gerbil
+Note that this configuration enables shared libraries: all gerbil
 programs will use shared libraries for `libgambit` and `libgerbil`
 linkage, resulting in significantly smaller executables.
 
@@ -126,21 +126,21 @@ $ gerbil new -n hello
 
 $ ls -latR
 .:
-total 24
-drwxrwxr-x 3 vyzo vyzo 4096 Sep 15 09:54 .
--rwxr-xr-x 1 vyzo vyzo  138 Sep 15 09:54 build.ss
--rw-rw-r-- 1 vyzo vyzo   16 Sep 15 09:54 gerbil.pkg
--rw-rw-r-- 1 vyzo vyzo   14 Sep 15 09:54 .gitignore
-drwxrwxr-x 2 vyzo vyzo 4096 Sep 15 09:54 hello
--rw-rw-r-- 1 vyzo vyzo  555 Sep 15 09:54 Makefile
-drwxrwxr-x 3 vyzo vyzo 4096 Sep 15 09:54 ..
+total 28
+drwxrwxr-x 3 vyzo vyzo 4096 Sep 24 09:52 .
+-rwxr-xr-x 1 vyzo vyzo  138 Sep 24 09:52 build.ss
+-rw-rw-r-- 1 vyzo vyzo   16 Sep 24 09:52 gerbil.pkg
+-rw-rw-r-- 1 vyzo vyzo   27 Sep 24 09:52 .gitignore
+drwxrwxr-x 2 vyzo vyzo 4096 Sep 24 09:52 hello
+-rw-rw-r-- 1 vyzo vyzo  593 Sep 24 09:52 Makefile
+drwxrwxr-x 8 vyzo vyzo 4096 Sep 24 09:52 ..
 
 ./hello:
 total 16
-drwxrwxr-x 2 vyzo vyzo 4096 Sep 15 09:54 .
-drwxrwxr-x 3 vyzo vyzo 4096 Sep 15 09:54 ..
--rw-rw-r-- 1 vyzo vyzo   90 Sep 15 09:54 lib.ss
--rw-rw-r-- 1 vyzo vyzo  617 Sep 15 09:54 main.ss
+drwxrwxr-x 2 vyzo vyzo 4096 Sep 24 09:52 .
+drwxrwxr-x 3 vyzo vyzo 4096 Sep 24 09:52 ..
+-rw-rw-r-- 1 vyzo vyzo  109 Sep 24 09:52 lib.ss
+-rw-rw-r-- 1 vyzo vyzo  777 Sep 24 09:52 main.ss
 
 $ cat gerbil.pkg
 (package: vyzo)
@@ -184,6 +184,10 @@ $ cat hello/main.ss
         ./lib)
 (export main)
 
+;; build manifest; generated during the build
+;; defines version-manifest which you can use for exact versioning
+(include "../manifest.ss")
+
 (def (main . args)
   (call-with-getopt hello-main args
     program: "hello"
@@ -224,22 +228,24 @@ $ gerbil build
 ... build in current directory
 ... compile hello/lib
 ... compile hello/main
-... compile exe hello/main -> ~/.gerbil/bin/hello
-/tmp/gxc.1694761212.5571132/vyzo__hello__main.scm:
-/home/vyzo/.gerbil/bin/hello.scmx:
-/tmp/gxc.1694761212.5571132/vyzo__hello__main.c:
-/home/vyzo/.gerbil/bin/hello.c:
-/home/vyzo/.gerbil/bin/hello_.c:
-
+... compile exe hello/main -> /home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/bin/hello
+/tmp/gxc.1695538439.3642368/vyzo__hello__main.scm:
+/home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/bin/hello.scmx:
+/tmp/gxc.1695538439.3642368/vyzo__hello__main.c:
+/home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/bin/hello.c:
+/home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/bin/hello_.c:
 ```
 
-And we have an executable, which is placed by default in `~/.gerbil/bin`.
+And we have an executable, which is placed by default in `.gerbil/bin`.
 You can change this by exporting the `GERBIL_PATH` variable.
 
 Of course our executable doesn't do anything right now, as we haven't filled any code:
 ```shell
-$ hello
-*** ERROR -- Implement me!
+$ ./.gerbil/bin/hello
+*** ERROR --
+*** ERROR IN ? [Error]: Implement me!
+--- continuation backtrace:
+0  error
 ```
 
 ## Write Some Code
@@ -296,16 +302,16 @@ $ gerbil build
 ... build in current directory
 ... compile hello/lib
 ... compile hello/main
-... compile exe hello/main -> ~/.gerbil/bin/hello
-/tmp/gxc.1694761770.3361619/vyzo__hello__lib.scm:
-/tmp/gxc.1694761770.3361619/vyzo__hello__main.scm:
-/home/vyzo/.gerbil/bin/hello.scmx:
-/tmp/gxc.1694761770.3361619/vyzo__hello__lib.c:
-/tmp/gxc.1694761770.3361619/vyzo__hello__main.c:
-/home/vyzo/.gerbil/bin/hello.c:
-/home/vyzo/.gerbil/bin/hello_.c:
+... compile exe hello/main -> /home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/bin/hello
+/tmp/gxc.1695538539.046348/vyzo__hello__lib.scm:
+/tmp/gxc.1695538539.046348/vyzo__hello__main.scm:
+/home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/bin/hello.scmx:
+/tmp/gxc.1695538539.046348/vyzo__hello__lib.c:
+/tmp/gxc.1695538539.046348/vyzo__hello__main.c:
+/home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/bin/hello.c:
+/home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/bin/hello_.c:
 
-$ hello world
+$ .gerbil/bin/hello world
 hello, world
 ```
 
@@ -322,38 +328,37 @@ optimization.
 
 For example:
 ```shell
-$ ldd $(which hello)
-	linux-vdso.so.1 (0x00007ffc3ffb0000)
-	libgerbil.so => /usr/local/gerbil/v0.17.0-247-gfba4fc7f/lib/libgerbil.so (0x00007f1304600000)
-	libgambit.so => /usr/local/gerbil/v0.17.0-247-gfba4fc7f/lib/libgambit.so (0x00007f1303c00000)
-	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f1306588000)
-	libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x00007f130455c000)
-	libsqlite3.so.0 => /lib/x86_64-linux-gnu/libsqlite3.so.0 (0x00007f1303ab3000)
-	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f1303800000)
-	/lib64/ld-linux-x86-64.so.2 (0x00007f13065c4000)
-	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f1303719000)
-	libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007f1303200000)
+$ ldd ./.gerbil/bin/hello
+	linux-vdso.so.1 (0x00007ffe5f3b6000)
+	libgerbil.so => /usr/local/gerbil/v0.17.0-294-g80c1d164/lib/libgerbil.so (0x00007fb29cc00000)
+	libgambit.so => /usr/local/gerbil/v0.17.0-294-g80c1d164/lib/libgambit.so (0x00007fb29c200000)
+	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fb29eb30000)
+	libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x00007fb29ea8c000)
+	libsqlite3.so.0 => /lib/x86_64-linux-gnu/libsqlite3.so.0 (0x00007fb29c0b3000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fb29be00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fb29eb6c000)
+	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fb29cb19000)
+	libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007fb29b800000)
 
 $ gerbil clean
 ... clean current package
-... remove ~/.gerbil/lib/vyzo/hello/lib.ssi
-... remove ~/.gerbil/lib/static/vyzo__hello__lib.scm
-... remove ~/.gerbil/bin/hello
-... remove ~/.gerbil/lib/static/vyzo__hello__main.scm
+... remove /home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/lib/vyzo/hello/lib.ssi
+... remove /home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/lib/static/vyzo__hello__lib.scm
+... remove /home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/bin/hello
+... remove /home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/lib/static/vyzo__hello__main.scm
 
 $ gerbil build --optimized
 ... build in current directory
 ... compile hello/lib
 ... compile hello/main
-... compile exe hello/main -> ~/.gerbil/bin/hello
+... compile exe hello/main -> /home/vyzo/src/vyzo/scratch/test/hello-world/.gerbil/bin/hello
 
-$ ldd $(which hello)
-	linux-vdso.so.1 (0x00007ffc8e93a000)
-	libgambit.so => /usr/local/gerbil/v0.17.0-247-gfba4fc7f/lib/libgambit.so (0x00007f58ba000000)
-	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f58b9c00000)
-	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f58ba956000)
-	/lib64/ld-linux-x86-64.so.2 (0x00007f58bab1b000)
-
+$ ldd ./.gerbil/bin/hello
+	linux-vdso.so.1 (0x00007fff585fc000)
+	libgambit.so => /usr/local/gerbil/v0.17.0-294-g80c1d164/lib/libgambit.so (0x00007f6b2e600000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6b2e200000)
+	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f6b2e502000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007f6b2efc9000)
 ```
 
 If you want your program to be statically linked to dependent
@@ -370,7 +375,7 @@ way to build release binaries is by using [docker](docker.md).
 
 The generated Makefile has two main rules: the default `linux-static`
 rule which builds static executables for your poject, and the utility
-`clean` rule to clean static build artifacts.
+`clean` rule to clean build artifacts.
 
 So all you have to do to build a release executable is this:
 ```shell
@@ -379,3 +384,62 @@ $ make
 
 This will build the release executable in `.gerbil/bin` in the current
 directory.
+
+## Dependency Management
+
+Once you have started building more complex projects, you will
+naturally want to organize them into multiple packages. You are also
+likely to have some external dependencies to package developed by
+others.
+
+The `gerbil` tool provides functionality to help with this situation.
+
+Here are some examples:
+- Search for packages in the user configured directories (or just the
+  default `mighty-gerbils` directory if none is configured):
+
+```shell
+# Search for packages
+$ gerbil pkg search
+github.com/mighty-gerbils/gerbil-crypto: Cryptography beyond OpenSSL
+github.com/mighty-gerbils/gerbil-ethereum: Ethereum support
+github.com/mighty-gerbils/gerbil-persist: Data persistence layer
+github.com/mighty-gerbils/gerbil-leveldb: LevelDB bindings
+github.com/mighty-gerbils/gerbil-libxml: libxml2 bindings
+github.com/mighty-gerbils/gerbil-libyaml: Libyaml bindings
+github.com/mighty-gerbils/gerbil-lmdb: LMDB bindings
+github.com/mighty-gerbils/gerbil-mysql: MySQL database driver
+github.com/mighty-gerbils/gerbil-poo: Prototype Object Orientation system
+github.com/mighty-gerbils/gerbil-utils: Various utilities
+
+# Search with keywords
+$ gerbil pkg search xml
+github.com/mighty-gerbils/gerbil-libxml: libxml2 bindings
+```
+
+- Add dependencies to your project:
+```shell
+$ gerbil deps -a -i github.com/mighty-gerbils/gerbil-libxml
+... cloning github.com/mighty-gerbils/gerbil-libxml
+... pulling
+... build github.com/mighty-gerbils/gerbil-libxml
+... compile foreign xml/_libxml
+... copy ssi xml/_libxml
+... compile loader xml/_libxml
+... compile xml/libxml
+... tagging packages
+```
+
+- List your project's dependencies:
+```shell
+$ gerbil deps
+github.com/mighty-gerbils/gerbil-libxml
+```
+
+## Where to go from here
+
+You can find more information about packages in the [Gerbil Package Manager](package-manager.md) page.
+
+You can find more information about the `gerbil` tooling in the [Universal Gerbil Binary and Tools](/reference/dev/bach.md) page.
+
+You can find more information about the build tool specifics in the [Gerbil Build Tool](/reference/dev/build.md) page.

--- a/doc/guide/package-manager.md
+++ b/doc/guide/package-manager.md
@@ -7,15 +7,15 @@ distributed through github, gitlab, or bitbucket.
 
 ::: tip usage
 ```
-gxpkg install pkg ...
-gxpkg update pkg ...
-gxpkg uninstall pkg ...
-gxpkg link pkg src
-gxpkg unlink pkg ...
-gxpkg build pkg ...
-gxpkg list
-gxpkg retag
-gxpkg search keyword ...
+gerbil pkg install pkg ...
+gerbil pkg update pkg ...
+gerbil pkg uninstall pkg ...
+gerbil pkg link pkg src
+gerbil pkg unlink pkg ...
+gerbil pkg build pkg ...
+gerbil pkg list
+gerbil pkg retag
+gerbil pkg search keyword ...
 ```
 :::
 
@@ -34,46 +34,66 @@ Any supported public provider git repo can serve a Gerbil package, provided that
 
 You can use `:std/build-script` to get a template script definition from the package build-spec.
 
-See gerbil-utils for an example package.
+See [gerbil-utils](https://github.com/mighty-gerbils/gerbil-utils) for an example package.
 
 ## Examples
 
-To install fare's gerbil-utils package:
+- To install fare's gerbil-utils package:
+```shell
+$ gerbil pkg install github.com/mighty-gerbils/gerbil-utils
+```
 
-`gxpkg install github.com/fare/gerbil-utils`
+- To link a local development package (here vyzo's gerbil-aws package):
+```shell
+$ gerbil pkg link github.com/vyzo/gerbil-aws gerbil-aws
+```
 
-To link a local development package (here vyzo's gerbil-aws package):
+- To list all installed (or linked) packages:
+```shell
+$ gerbil pkg list
+```
 
-`gxpkg link github.com/mighty-gerbils/gerbil-aws gerbil-aws`
+- To update all packages:
+```shell
+$ gerbil pkg update all
+```
 
-To list all installed (or linked) packages:
+- To rebuild a package and its transitive dependencies:
+```shell
+gerbil pkg build github.com/mighty-gerbils/gerbil-utils
+```
 
-`gxpkg list`
+- To rebuild all packages:
+```shell
+gerbil pkg build all`
+```
 
-To update all packages:
+## Package Directories
 
-`gxpkg update all`
+Package lists come from directories, which can be any repo on github
+that has a `package-list` file or just a URL pointing to a package
+list.
 
-To rebuild a package and its transitive dependencies:
+This list follows the simplest and most extensible format: an
+association list where the car is the package and the cdr is a plist
+of the package properties, with keyword keys. The only required key is
+`description:`.
 
-`gxpkg build github.com/fare/gerbil-utils`
+This is designed so that it is trivial to create a new directory; in
+fact users are encouraged to create their own directories for their
+packages and share them with each other.
 
-To rebuild all packages:
+By default, the [Mighty Gerbils
+directory](https://github.com/mighty-gerbils/gerbil-directory) is
+searched, as these are packaged developed and maintained by the Gerbil
+Core Team.
 
-`gxpkg build all`
-
-To search for packages created by vyzo using the package directory:
-
-`gxpkg search vyzo`
-
-## Known Gerbil Packages
-
-We maintain a list of known Gerbil packages in the [Gerbil Package Directory](https://github.com/mighty-gerbils/gerbil-directory).
-Feel free to open a PR in that repo to list your own packages!
+You can add a new directory with the `gerbil pkg dir -a directory-repo-or-url ...`
+command.
 
 ## A Word of Caution
 
-The build script is currently not sandboxed; it runs with user privileges and it is an arbitrary script. We originally planned to address this by creating a restricted sandbox language for package build scripts. But you can only go so far in a language that thrives in compile-time evaluation; remember, it's macros all the way!
+The build script is not sandboxed; it runs with user privileges and it is an arbitrary script. We originally planned to address this by creating a restricted sandbox language for package build scripts. But you can only go so far in a language that thrives in compile-time evaluation; remember, it's macros all the way!
 
 You can quickly vet a package by inspecting the gerbil.pkg manifest and the build script itself. If it uses the standard script template or just invokes make with a build-spec, then it should be a reasonably behaved package. Of course, who knows what surprises could be lurking in a macro deep in the sources, so where to stop?
 

--- a/doc/reference/dev/bach.md
+++ b/doc/reference/dev/bach.md
@@ -1,3 +1,254 @@
 # The Gerbil Universal Binary and Tools
 
-(TODO)
+If you look at the Gerbil installation bin directory, you will see someghing like the following:
+```shell
+$ ll -h /usr/local/gerbil/bin/
+total 11M
+-rwxrwxr-x 1 vyzo vyzo  19K Sep 24 10:20 gambuild-C
+-rwxrwxr-x 1 vyzo vyzo  11M Sep 24 10:23 gerbil
+-rwxrwxr-x 1 vyzo vyzo 151K Sep 24 10:20 gsc
+lrwxrwxrwx 1 vyzo vyzo    6 Sep 24 10:23 gxc -> gerbil
+lrwxrwxrwx 1 vyzo vyzo    6 Sep 24 14:43 gxensemble -> gerbil
+lrwxrwxrwx 1 vyzo vyzo    6 Sep 24 10:23 gxi -> gerbil
+lrwxrwxrwx 1 vyzo vyzo    6 Sep 24 14:43 gxpkg -> gerbil
+lrwxrwxrwx 1 vyzo vyzo    6 Sep 24 14:43 gxprof -> gerbil
+lrwxrwxrwx 1 vyzo vyzo    6 Sep 24 14:43 gxtags -> gerbil
+lrwxrwxrwx 1 vyzo vyzo    6 Sep 24 14:43 gxtest -> gerbil
+```
+
+As you notice all the programs distributed with Gerbil link to a
+single universal binary, `gerbil`.  We call this program
+affectionately **Bach** after the great composer of timeless music.
+
+The `gerbil` binary includes all modules from the core system compiled
+in and has specialized main functions for the interpreter and
+compiler.
+
+It also fronts for all tooling, which is implemented with dynamic
+loading of dynamically compiled executable modules depending on the
+linked executable name.  Some of the tooling functionality is actually
+explicitly lifted at top level: things like the build tool and
+dependency management commands of the `gxpkg` tool.
+
+Here we give an overview of all commands and tools supported by Bach.
+
+## Using Bach
+
+The Gerbil universal binary has the following usage:
+```shell
+$ gerbil help
+Usage: gerbil [option ...] arguments ...
+
+Options:
+  -h|--help                        display this help message exit
+  -v|--version                     display the system version and exit
+
+Arguments:
+  <cmd> cmd-arg ...                execute a builtin tool command
+  arg ...                          drop to the gerbil interpreter
+
+Commands:
+  new                              create a new project template (gxpkg new)
+  build                            build a gerbil package (gxpkg build)
+  deps                             manage dependencies for a package (gxpkg deps)
+  clean                            clean build artifactacts for a package (gxpkg clean)
+  pkg                              invoke the gerbil package manager (gxpkg)
+  test                             run tests (gxtest)
+  tags                             create emacs tags (gxtags)
+  prof                             profile a dynamic executable module (gxprof)
+  ensemble                         invoke the gerbil actor ensemble manager (gxensemble)
+  interactive                      invoke the gerbil interpreter (gxi)
+  compile                          invoke the gerbil compiler (gxc)
+  help <cmd>                       display help for a tool command
+
+Try gerbil help <cmd> for help on tool command usage
+```
+
+### `gxi`
+
+The Gerbil interpreter is `gxi`, but can also be invoked with `gerbil interactve`.
+It has the following usage:
+```shell
+$ gxi -h
+Usage: gxi [options ...] arguments ...
+
+Options:
+  -h|--help|help                   display this help message exit
+  -v||--version|version            display the system version and exit
+  -l|--lang module                 set the current interpretation language; must precede any evaluation
+  -e|--eval <expr>                 evaluate an expression
+
+Arguments:
+  -                                enter the repl
+  :module                          import library module; if it exports a main function, apply it with the remaining arguments
+  file                             load file; if it defines a main function, apply it with the remaining arguments
+
+When no arguments or options other than --lang are supplied, enters the interactive repl
+```
+
+### `gxc`
+
+The Gerbil compiler is `gxc`, but can also be invoked with `gerbil compile`.
+It has the following usage:
+```shell
+$ gxc -h
+gxc [options...] <file> ...
+Options:
+ -h,--help                   display this help message and exit
+ -d <dir>                    set compiler output directory; defaults to $GERBIL_PATH/lib
+ -exe                        compile an executable
+ -o <file>                   set executable output file
+ -O                          optimize gerbil source
+ -full-program-optimization  perform full program optimization
+ -static                     link the executable's external library dependencies statically
+ -s                          keep intermediate .scm files
+ -S                          don't invoke gsc
+ -v                          be verbose during compilation
+ -g                          compile with debug symbols; c code is compiled with -g
+ -no-ssxi                    don't generate .ssxi modules for cross-module optimization
+ -include-gambit-sharp       include _gambit# with necessary cond expand features
+ -prelude <sexpr>            add [-prelude <sexpr>] to gsc options
+ -cc-options <string>        add [-cc-options <string>] to gsc options
+ -ld-options <string>        add [-ld-options <string>] to gsc options
+ -gsc-flag   <opt>           add [<opt>] to gsc options
+ -gsc-option <opt> <string>  add [<opt> <string>] to gsc options
+```
+
+### `gerbil new`
+```shell
+$ gerbil help new
+Usage: gxpkg new [command-option ...]
+       create a new package template in the current directory
+
+Command Options:
+ -p --package <package>           the package prefix for your project; defaults to the current username [default: vyzo]
+ -n --name <name>                 the package name; defaults to the current directory name [default: gerbil]
+ -l --link <link>                 link this package with a public package name; for example: github.com/your-user/your-package [default: #f]
+```
+
+### `gerbil build`
+```shell
+$ gerbil help build
+Usage: gxpkg build [command-option ...] <pkg> ...
+       rebuild one or more packages and their dependents
+
+Command Options:
+ -l --local                       do the action in the local package context, unless GERBIL_PATH is set
+ -R --release                     build released (static) executables
+ -O --optimized                   build full program optimized executables
+
+Arguments:
+ pkg                              package to build; all for all packages, omit to build in current directory
+```
+
+### `gerbil clean`
+```shell
+$ gerbil help clean
+Usage: gxpkg clean [command-option ...] <pkg> ...
+       clean compilation artefacts from one or more packages
+
+Command Options:
+ -l --local                       do the action in the local package context, unless GERBIL_PATH is set
+
+Arguments:
+ pkg                              package to clean; all for all packages, omit to clean in current directory
+```
+
+### `gerbil pkg`
+```shell
+$ gerbil help pkg
+gxpkg: The Gerbil Package Manager
+
+Usage: gxpkg  <command> command-arg ...
+
+Commands:
+ new                              create a new package template in the current directory
+ build                            rebuild one or more packages and their dependents
+ clean                            clean compilation artefacts from one or more packages
+ deps                             manage dependencies for the current project
+ link                             link a local development package
+ unlink                           unlink one or more local development packages
+ install                          install one or more packages
+ uninstall                        uninstall one or more packages
+ update                           update one or more packages
+ list                             list installed packages
+ retag                            retag installed packages
+ search                           search the package directory
+ dir                              manage the directory list
+ env                              execute a command within the local package context
+ help                             display help; help <command> for command help
+```
+
+### `gerbil test`
+```shell
+$ gerbil help test
+gxtest: run Gerbil tests in the command line
+
+Usage: gxtest [option ...] <args> ...
+
+Options:
+ -v                               run in verbose mode where all test execution progress is displayed in stdout.
+ -r --run <run>                   only run test suites whose name matches a given regex [default: #f]
+ -D  <features>                   define one or more conditional expansion feature (comma separated) for enabling tests that require external services [default: #f]
+ -h --help                        display help
+
+Arguments:
+ args                             test files or directories to execute tests in; appending /... to a directory will recursively execute or tests in it. If no arguments are passed, all tests in the current directory are executed.
+```
+
+### `gerbil tags`
+```shell
+$ gerbil help tags
+gxtags: generate emacs tags for Gerbil code
+
+Usage: gxtags [option ...] <input> ...
+
+Options:
+ -a                               append to existing tag file
+ -o  <output>                     explicit name of file for tag table [default: TAGS]
+ -h --help                        display help
+
+Arguments:
+ input                            source file or directory
+```
+
+### `gerbil prof`
+```shell
+$ gerbil help prof
+gxprof: The Gerbil profiler
+
+Usage: gxprof [option ...] [<module>] <module-args> ...
+
+Options:
+ -o --output <output>             gxprof output file [default: gxprof.out]
+ --heartbeat  <heartbeat>         heartbeat interval for sampling, in seconds [default: .001]
+ -k --ignore-kernel-frames        ignore kernel functions in the analysis
+ -h --help                        display help
+
+Arguments:
+ module                           dynamic executable module to run; analyze an existing output file if omitted [default: #f]
+ module-args                      arguments to pass to the executable module's main
+```
+
+### `gerbil ensemble`
+```shell
+$ gerbil help ensemble
+gxensemble: the Gerbil Actor Ensemble Manager
+
+Usage: gxensemble  <command> command-arg ...
+
+Commands:
+ run                              run a server in the ensemble
+ registry                         runs the ensemble registry
+ load                             loads code in a running server
+ eval                             evals code in a running server
+ repl                             provides a repl for a running server
+ ping                             pings a server or actor in the server
+ lookup                           looks up a server by id or role
+ shutdown                         shuts down an actor, server, or the entire ensemble including the registry
+ admin                            ensemble administrative operations
+ list                             list server state
+ ca                               ensemble CA operations
+ package                          package ensemble state to ship an actor server environment
+ help                             display help; help <command> for command help
+```

--- a/doc/reference/dev/build.md
+++ b/doc/reference/dev/build.md
@@ -1,8 +1,8 @@
-# The Standard Library Build Tool
+# The Gerbil Build Tool
 
 Building complex libraries and executables by invoking `gxc` quickly gets tedious. When you reach that point of complexity and you need a build tool, you can use the [`:std/make` library module](/reference/std/make.md) which provides a modest build tool that can handle reasonably complex project building.
 
-## The project source code
+## A Trivial Project
 
 For illustration purposes, we'll make a hello world library module and an executable that uses it.
 
@@ -23,7 +23,7 @@ $ cat hello.ss
   (for-each hello args))
 ```
 
-## The standard build script template
+### The Standard Build Script Template
 
 The recommended way to write a build script is to use the template provided by the standard library.
 You can do this by importing `:std/build-script` and using the `defbuild-script` macro.
@@ -52,7 +52,7 @@ $ ./build.ss
 ...
 ```
 
-## Intermediate build scripts
+### Intermediate Build Scripts
 
 Here is a build script that uses an environment variable to determine
 whether to build an optimized fully static binary or a normally linked binary:
@@ -68,7 +68,8 @@ $ cat build.ss
        '(exe: "hello"))))
 ```
 
-If you are in your development environment and building executables for your host, then you can just invoke it as
+If you are in your development environment and building executables
+for your host, then you can just invoke it as
 ```bash
 $ ./build.ss
 ```
@@ -90,8 +91,9 @@ link all stdlib foreign dependencies.
 
 ## Using the Gerbil build tool
 
-You don't normally have to run `build.ss` directly, you use the
-`gerbil build` which will run it for you:
+Normally, you should not run `build.ss` directly but you use the
+`gerbil build` tool insted. This will run it for you with the proper build
+environment:
 
 ```shell
 $ gerbil build
@@ -114,5 +116,493 @@ $ gerbil build --optimized
 And to build optimized release executables, you can do this inside
 your [docker build container](/guide/docker.md):
 ```shell
-gerbil build --release --optimized
+$ gerbil build --release --optimized
 ```
+
+## Dependency Management and Build Isolation
+
+So far we have illustrated projects without any package dependencies;
+things get more interesting when we factor those in. The build tool
+provides functionality to manage your project dependencies and build
+your project cleanly in an isolated environment irrespective of the
+current global state in `~/.gerbil`.
+
+All this is best explained with an example, but first let's explicitly
+state the problem so that you can understand what follows:
+- The Gerbil build environment is dictated by the `GERBIL_PATH` environment variable.
+- If you don't set this variable, it will default to `~/.gerbil`.
+- This is totally fine for casual or interactive use, where you want
+  to install things globally to access libraries in the interpreter
+  and have binaries in your path.
+- However, it is entirely inappropriate when building and assembling
+  your project, as a dirty `~/.gerbil` can break the build and
+  generally have unintended side effects because of state.
+- Prior to Gerbil v0.18, the recommended best practice was to
+  _manually_ set `GERBIL_PATH` on a per project basis to isolate your
+  builds.
+- This works, but it is poor developer UX; so in Gerbil v0.18 we have
+  systematized it and unless you explicitly set `GERBIL_PATH` (you can
+  still do that if you want full control of the build environment),
+  when building a project locally the build tool will automatically
+  create a build environment for your project and set `GERBIL_PATH`
+  for relevant commands.
+
+### A Simple Project with an External Dependency
+
+### The Project Structure Source Code
+
+So let's start over again: this time we'll build a primitive web
+scrapper: it is a command line tool that takes a URL, makes an http
+request and parses the html output using `parse-html` from the
+[gerbil-libxml](https://github.com/mighty-gerbils/gerbil-libxml)
+package.
+
+First, let's create the project:
+```shell
+$ mkdir scrape-it
+$ cd scrape-it
+$ gerbil new -n scraper
+$ ls -lR
+.:
+total 16
+-rwxr-xr-x 1 vyzo vyzo  144 Sep 24 11:33 build.ss
+-rw-rw-r-- 1 vyzo vyzo   16 Sep 24 11:33 gerbil.pkg
+-rw-rw-r-- 1 vyzo vyzo  478 Sep 24 11:33 Makefile
+drwxrwxr-x 2 vyzo vyzo 4096 Sep 24 11:33 scraper
+
+./scraper:
+total 8
+-rw-rw-r-- 1 vyzo vyzo 109 Sep 24 11:33 lib.ss
+-rw-rw-r-- 1 vyzo vyzo 791 Sep 24 11:33 main.ss
+```
+
+Now let's add our dependency:
+```shell
+$ gerbil deps -a -i github.com/mighty-gerbils/gerbil-libxml
+... cloning github.com/mighty-gerbils/gerbil-libxml
+... pulling
+... build github.com/mighty-gerbils/gerbil-libxml
+... compile foreign xml/_libxml
+... copy ssi xml/_libxml
+... compile loader xml/_libxml
+... compile xml/libxml
+... tagging packages
+```
+
+Next, we add the code for the scrapper:
+```shell
+ cat scraper/lib.ss
+;;; -*- Gerbil -*-
+(import :std/error
+        :std/sugar
+        :std/net/request
+        :clan/xml/libxml)
+(export #t)
+
+(def (scrape url)
+  (let (req (http-get url redirect: #t))
+    (unless (= (request-status req) 200)
+      (error "HTTP request did not succeed" status: (request-status-text req)))
+    (let (content-type (assget "Content-Type"(request-headers req)))
+      (unless (string-prefix? "text/html" content-type)
+        (error "HTTP response did not return html" content-type: content-type)))
+    (parse-html (request-text req))))
+
+$ cat scraper/main.ss
+;;; -*- Gerbil -*-
+(import :std/error
+        :std/sugar
+        :std/getopt
+        :gerbil/gambit
+        ./lib)
+(export main)
+
+;; build manifest; generated during the build
+;; defines version-manifest which you can use for exact versioning
+(include "../manifest.ss")
+
+(def (main . args)
+  (call-with-getopt scraper-main args
+    program: "scraper"
+    help: "A simple web scraper"
+    (argument 'url help: "URL to scrape")))
+
+(def* scraper-main
+  ((opt)
+   (scraper-main/options opt))
+  ((cmd opt)
+   (scraper-main/command cmd opt)))
+
+;;; Implement this if your CLI doesn't have commands
+(def (scraper-main/options opt)
+  (let (sxml (scrape (hash-ref opt 'url)))
+    (pretty-print sxml)))
+
+;;; Implement this if your CLI has commands
+(def (scraper-main/command cmd opt)
+  (error "Implement me!"))
+
+$ cat build.ss
+#!/usr/bin/env gxi
+;;; -*- Gerbil -*-
+(import :std/build-script :std/make)
+
+(defbuild-script
+  `("scraper/lib"
+    (exe: "scraper/main" bin: "scraper"
+          "-cc-options" ,(shell-config "xml2-config" "--cflags")
+          "-ld-options" ,(shell-config "xml2-config" "--libs"))))
+
+```
+
+And let's build it and run it:
+```shell
+$ gerbil build
+... build in current directory
+... compile scraper/main
+... compile exe scraper/main -> /home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper
+/tmp/gxc.1695545021.0991077/clan__xml___libxml.scm:
+/tmp/gxc.1695545021.0991077/clan__xml__libxml.scm:
+/tmp/gxc.1695545021.0991077/vyzo__scraper__lib.scm:
+/tmp/gxc.1695545021.0991077/vyzo__scraper__main.scm:
+/home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper.scmx:
+/tmp/gxc.1695545021.0991077/clan__xml___libxml.c:
+/tmp/gxc.1695545021.0991077/clan__xml__libxml.c:
+/tmp/gxc.1695545021.0991077/vyzo__scraper__lib.c:
+/tmp/gxc.1695545021.0991077/vyzo__scraper__main.c:
+/home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper.c:
+/home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper_.c:
+
+$ ./.gerbil/bin/scraper http://hackzen.org
+(*TOP* (html (head (title "(hackzen.org)")
+                   (link (@ (rel "stylesheet") (type "text/css") (href "style.css"))))
+             (body "\n    "
+                   (h1 (@ (id "header")) "(hackzen.org)")
+                   "\n    "
+                   "\n    "
+                   (div (a (@ (href "http://xkcd.com/297/")) (img (@ (src "parens.png")))))
+                   "\n    "
+                   (br)
+                   (div (a (@ (href "robots.html")) "(robots)"))
+                   "\n    "
+                   (div (a (@ (href "gerbil/index.html")) "(gerbils)"))
+                   "\n    "
+                   (div (a (@ (href "humans.html")) "(humans)"))
+                   "\n    "
+                   (div (a (@ (href "nic9/index.html")) "[N1C#09]"))
+                   "\n    "
+                   (br)
+                   (script (@ (src "harhar.js"))))))
+```
+
+So everything worked smoothly with the build, and the program works;
+let's look at what happend under the hood.
+
+### The Build Environment
+
+The first thing that you should notice is that the build artifacts are
+placed in a local `.gerbil` directory and not the global user
+`~/.gerbil`.
+
+Now let's look at what's in there:
+```shell
+$ ls -lR .gerbil/
+.gerbil/:
+total 12
+drwxr-xr-x 2 vyzo vyzo 4096 Sep 24 11:43 bin
+drwxr-xr-x 5 vyzo vyzo 4096 Sep 24 11:42 lib
+drwxr-xr-x 3 vyzo vyzo 4096 Sep 24 11:34 pkg
+
+.gerbil/bin:
+total 220
+-rwxrwxr-x 1 vyzo vyzo 222312 Sep 24 11:43 scraper
+
+.gerbil/lib:
+total 12
+drwxr-xr-x 3 vyzo vyzo 4096 Sep 24 11:34 clan
+drwxr-xr-x 2 vyzo vyzo 4096 Sep 24 11:43 static
+drwxr-xr-x 3 vyzo vyzo 4096 Sep 24 11:42 vyzo
+
+.gerbil/lib/clan:
+total 4
+drwxr-xr-x 2 vyzo vyzo 4096 Sep 24 11:34 xml
+
+.gerbil/lib/clan/xml:
+total 212
+-rwxrwxr-x 1 vyzo vyzo 47448 Sep 24 11:34 libxml__0.o1
+-rwxrwxr-x 1 vyzo vyzo 18656 Sep 24 11:34 libxml__1.o1
+-rwxrwxr-x 1 vyzo vyzo 92472 Sep 24 11:34 _libxml.o1
+-rwxrwxr-x 1 vyzo vyzo 17800 Sep 24 11:34 _libxml__rt.o1
+-rwxrwxr-x 1 vyzo vyzo 18160 Sep 24 11:34 libxml__rt.o1
+-rwxrwxr-x 1 vyzo vyzo  1543 Sep 24 11:34 _libxml.ssi
+-rw-r--r-- 1 vyzo vyzo  4072 Sep 24 11:34 libxml.ssi
+-rw-r--r-- 1 vyzo vyzo  1832 Sep 24 11:34 libxml.ssxi.ss
+
+.gerbil/lib/static:
+total 48
+-rwxrwxr-x 1 vyzo vyzo 12419 Sep 24 11:34 clan__xml___libxml.scm
+-rwxrwxr-x 1 vyzo vyzo 21371 Sep 24 11:34 clan__xml__libxml.scm
+-rwxrwxr-x 1 vyzo vyzo  2109 Sep 24 11:42 vyzo__scraper__lib.scm
+-rwxrwxr-x 1 vyzo vyzo  2404 Sep 24 11:43 vyzo__scraper__main.scm
+
+.gerbil/lib/vyzo:
+total 4
+drwxr-xr-x 2 vyzo vyzo 4096 Sep 24 11:42 scraper
+
+.gerbil/lib/vyzo/scraper:
+total 64
+-rwxrwxr-x 1 vyzo vyzo 19008 Sep 24 11:42 lib__0.o1
+-rwxrwxr-x 1 vyzo vyzo 18488 Sep 24 11:42 lib__rt.o1
+-rw-r--r-- 1 vyzo vyzo   293 Sep 24 11:42 lib.ssi
+-rw-r--r-- 1 vyzo vyzo   108 Sep 24 11:42 lib.ssxi.ss
+-rw-r--r-- 1 vyzo vyzo  2404 Sep 24 11:43 main__0.scm
+-rw-r--r-- 1 vyzo vyzo   297 Sep 24 11:43 main__rt.scm
+-rw-r--r-- 1 vyzo vyzo   738 Sep 24 11:43 main.ssi
+-rw-r--r-- 1 vyzo vyzo   424 Sep 24 11:43 main.ssxi.ss
+
+.gerbil/pkg:
+total 8
+drwxr-xr-x 3 vyzo vyzo 4096 Sep 24 11:34 github.com
+-rw-rw-r-- 1 vyzo vyzo 3599 Sep 24 11:34 TAGS
+
+.gerbil/pkg/github.com:
+total 4
+drwxr-xr-x 3 vyzo vyzo 4096 Sep 24 11:34 mighty-gerbils
+
+.gerbil/pkg/github.com/mighty-gerbils:
+total 8
+drwxrwxr-x 4 vyzo vyzo 4096 Sep 24 11:34 gerbil-libxml
+-rw-rw-r-- 1 vyzo vyzo  131 Sep 24 11:34 gerbil-libxml.manifest
+
+.gerbil/pkg/github.com/mighty-gerbils/gerbil-libxml:
+total 64
+-rw-rw-r-- 1 vyzo vyzo   362 Sep 24 11:34 build-deps
+-rwxrwxr-x 1 vyzo vyzo   306 Sep 24 11:34 build.ss
+-rw-rw-r-- 1 vyzo vyzo    16 Sep 24 11:34 gerbil.pkg
+-rw-rw-r-- 1 vyzo vyzo 11358 Sep 24 11:34 LICENSE-APACHE-2.0.txt
+-rw-rw-r-- 1 vyzo vyzo 26430 Sep 24 11:34 LICENSE-LGPL.txt
+-rw-rw-r-- 1 vyzo vyzo   172 Sep 24 11:34 manifest.ss
+-rw-rw-r-- 1 vyzo vyzo  3535 Sep 24 11:34 README.md
+drwxrwxr-x 2 vyzo vyzo  4096 Sep 24 11:34 xml
+
+.gerbil/pkg/github.com/mighty-gerbils/gerbil-libxml/xml:
+total 28
+-rw-rw-r-- 1 vyzo vyzo 12419 Sep 24 11:34 _libxml.scm
+-rw-rw-r-- 1 vyzo vyzo  6351 Sep 24 11:34 libxml.ss
+-rw-rw-r-- 1 vyzo vyzo  1543 Sep 24 11:34 _libxml.ssi
+```
+
+- `.gerbil/bin` contains the binary output.
+- `.gerbil/lib` contains the library build artifacts.
+- `.gerbil/pkg` contains the packages involved
+
+The most important one here is the `.gerbil/pkg` directory, this is
+where dependencies live.
+
+### Version Manifests
+
+You will notice a salient new file that appeared in our directory:
+```shell
+$ ll manifest.ss
+-rw-rw-r-- 1 vyzo vyzo 205 Sep 24 11:43 manifest.ss
+
+$ cat manifest.ss
+(def version-manifest
+     '(("scrape-it" . "unknown")
+       ("Gerbil" . "0.17.0-309-g5ebf1095")
+       ("Gambit" . "v4.9.5-40-g24201248")
+       ("github.com/mighty-gerbils/gerbil-libxml" . "b08e5d8")))
+```
+
+This file provides exact versioning for all parts of the project
+involved, getting information from `git`.  For `gerbil-libxml` you'll
+notice that the version is a commit hash, as at the time of writing
+there are not any _version tags_ in the package (see next section).
+
+Note that the version of our project (`scrape-it`) is unknow; that's
+because we have not initialized a git repository for our project.
+Once we do that, it stops being unknown and it points to the current commit:
+```shell
+$ git init
+Initialized empty Git repository in /home/vyzo/src/vyzo/scratch/test/scrape-it/.git/
+
+$ git add .
+$ git status
+On branch master
+
+No commits yet
+
+Changes to be committed:
+  (use "git rm --cached <file>..." to unstage)
+	new file:   .gitignore
+	new file:   Makefile
+	new file:   build.ss
+	new file:   gerbil.pkg
+	new file:   scraper/lib.ss
+	new file:   scraper/main.ss
+
+$ git commit -m "initial commit"
+[master (root-commit) 0ba7240] initial commit
+ 6 files changed, 83 insertions(+)
+ create mode 100644 .gitignore
+ create mode 100644 Makefile
+ create mode 100755 build.ss
+ create mode 100644 gerbil.pkg
+ create mode 100644 scraper/lib.ss
+ create mode 100644 scraper/main.ss
+
+ $ gerbil clean
+... clean current package
+... remove /home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/lib/vyzo/scraper/lib.ssi
+... remove /home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/lib/static/vyzo__scraper__lib.scm
+... remove /home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper
+... remove /home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/lib/static/vyzo__scraper__main.scm
+
+$ gerbil build
+... build in current directory
+... compile scraper/lib
+... compile scraper/main
+... compile exe scraper/main -> /home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper
+/tmp/gxc.1695546027.0358357/clan__xml___libxml.scm:
+/tmp/gxc.1695546027.0358357/clan__xml__libxml.scm:
+/tmp/gxc.1695546027.0358357/vyzo__scraper__lib.scm:
+/tmp/gxc.1695546027.0358357/vyzo__scraper__main.scm:
+/home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper.scmx:
+/tmp/gxc.1695546027.0358357/clan__xml___libxml.c:
+/tmp/gxc.1695546027.0358357/clan__xml__libxml.c:
+/tmp/gxc.1695546027.0358357/vyzo__scraper__lib.c:
+/tmp/gxc.1695546027.0358357/vyzo__scraper__main.c:
+/home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper.c:
+/home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper_.c:
+
+$ cat manifest.ss
+(def version-manifest
+     '(("scrape-it" . "0ba7240")
+       ("Gerbil" . "0.17.0-309-g5ebf1095")
+       ("Gambit" . "v4.9.5-40-g24201248")
+       ("github.com/mighty-gerbils/gerbil-libxml" . "b08e5d8")))
+```
+
+We can integrate the version manifest into our program's cli so that
+when a user reports a bug or there is some failure in your production
+environment, you can query the binary to find the exact version and
+know exactly what code was used to compile it.
+
+Here, we add a `-v/--version` flag to print the version and exit:
+```shell
+$ cat scraper/main.ss
+;;; -*- Gerbil -*-
+(import :std/error
+        :std/sugar
+        :std/getopt
+        :gerbil/gambit
+        ./lib)
+(export main)
+
+;; build manifest; generated during the build
+;; defines version-manifest which you can use for exact versioning
+(include "../manifest.ss")
+
+(def (main . args)
+  (call-with-getopt scraper-main args
+    program: "scraper"
+    help: "A simple web scraper"
+    (flag 'version "-v" "--version" help: "display program version and exit")
+    (optional-argument 'url help: "URL to scrape")))
+
+(def* scraper-main
+  ((opt)
+   (scraper-main/options opt))
+  ((cmd opt)
+   (scraper-main/command cmd opt)))
+
+;;; Implement this if your CLI doesn't have commands
+(def (scraper-main/options opt)
+  (when (hash-get opt 'version)
+    (pretty-print version-manifest)
+    (exit 0))
+  (let (sxml (scrape (hash-ref opt 'url)))
+    (pretty-print sxml)))
+
+;;; Implement this if your CLI has commands
+(def (scraper-main/command cmd opt)
+  (error "Implement me!"))
+
+
+$ gerbil build
+... build in current directory
+... compile scraper/main
+... compile exe scraper/main -> /home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper
+/tmp/gxc.1695546226.3194306/clan__xml___libxml.scm:
+/tmp/gxc.1695546226.3194306/clan__xml__libxml.scm:
+/tmp/gxc.1695546226.3194306/vyzo__scraper__lib.scm:
+/tmp/gxc.1695546226.3194306/vyzo__scraper__main.scm:
+/home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper.scmx:
+/tmp/gxc.1695546226.3194306/clan__xml___libxml.c:
+/tmp/gxc.1695546226.3194306/clan__xml__libxml.c:
+/tmp/gxc.1695546226.3194306/vyzo__scraper__lib.c:
+/tmp/gxc.1695546226.3194306/vyzo__scraper__main.c:
+/home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper.c:
+/home/vyzo/src/vyzo/scratch/test/scrape-it/.gerbil/bin/scraper_.c:
+
+```
+
+And voila:
+```shell
+$ ./.gerbil/bin/scraper -v
+(("scrape-it" . "0ba7240")
+ ("Gerbil" . "0.17.0-309-g5ebf1095")
+ ("Gambit" . "v4.9.5-40-g24201248")
+ ("github.com/mighty-gerbils/gerbil-libxml" . "b08e5d8"))
+```
+
+### Semantic Versioning
+
+As you've probably noticed, version information comes from `git`. The natural follow up question is "can we version packages".
+
+The answer is "Yes, of course!". Gerbil uses tags for version and
+implements _semantic versioning_ to select the correct version of your
+packages when there differing versions specified.  You can request a
+specific version of a package by simple appending `@<version-tag>` to
+the package name when specifying a dependency. This will ensure that
+the correct version of the code is checked out according to the
+dependencies in the transitive package list.
+
+The rules for version selection when there are different version of
+the same package involved in the transitive dependency list are as
+follows:
+- Always select the latest semantic version, with tags of the form
+  `vX[.Y[.Z]]` parsed as major, minor, and patch version
+- The `master` and `main` branches are always considered versioned as
+  higher than any semantic version tag.
+- If the package version specifies two different branches or commit
+  hashes, then it is considered a _hard_ conflict and the user has to
+  intervene to resolve the issue.
+
+Note that Gerbil's semantic versioning doesn't follow the strict
+"different major versions are incompatible" rule. We considered this
+and our long experience with developing production software has led us
+to the conclusion that it simply doesn't work in practice -- see Go's
+ugly required version appending once you are over v1 or the mess with
+Rust.  What we advocate instead is for you to make a `v2` subpackage
+within your package that implements forward functionality without
+breaking the API of `v1` and so on for higher versions.
+
+## Testing your package
+
+So at this point you are naturally wondering how to run tests for your
+package, given the build isolation properties of the tooling.
+
+This is actually very simple: the `gerbil pkg env` command provides
+you with the ability to run command with the local build GERBIL_PATH
+set for you.
+
+So in order to run your tests, all you have to do is:
+```
+$ gerbil pkg env gxtest ./...
+```
+
+## Where to go from here
+
+See the [Gerbil Universal Binary and Tools](bach.md) page for more
+information about the Gerbil tooling.

--- a/doc/reference/dev/optimizing.md
+++ b/doc/reference/dev/optimizing.md
@@ -77,7 +77,7 @@ checking and show you your performance envelope.
 
 ::: tip Note
 We do not advocate shipping programs compiled like this in production
-servers, unless you want your devops to be debugging segfaults. The
+servers, unless you want your devops to be debugging segfaults. These
 programs are also nearly impossible to debug because everything is
 lumped in a single host function and you might not even get a stack
 trace with gdb.

--- a/src/gerbil/main.ss
+++ b/src/gerbil/main.ss
@@ -53,6 +53,7 @@ package: gerbil
 (def builtin-tool-commands
   '(("new"         "gxpkg" "new")
     ("build"       "gxpkg" "build")
+    ("deps"        "gxpkg" "deps")
     ("clean"       "gxpkg" "clean")
     ("pkg"         "gxpkg")
     ("test"        "gxtest")
@@ -65,6 +66,7 @@ package: gerbil
 (def builtin-tool-help
   '(("new"         "gxpkg" "help" "new")
     ("build"       "gxpkg" "help" "build")
+    ("deps"        "gxpkg" "help" "deps")
     ("clean"       "gxpkg" "help" "clean")
     ("pkg"         "gxpkg" "help")
     ("test"        "gxtest" "-h")
@@ -79,7 +81,7 @@ package: gerbil
   (displayln)
   (displayln "Options: ")
   (displayln "  -h|--help                        display this help message exit")
-  (displayln "  -v|--version|version             display the system version and exit")
+  (displayln "  -v|--version                     display the system version and exit")
   (displayln)
   (displayln "Arguments: ")
   (displayln "  <cmd> cmd-arg ...                execute a builtin tool command")
@@ -88,6 +90,7 @@ package: gerbil
   (displayln "Commands:")
   (displayln "  new                              create a new project template (gxpkg new)")
   (displayln "  build                            build a gerbil package (gxpkg build)")
+  (displayln "  deps                             manage dependencies for a package (gxpkg deps)")
   (displayln "  clean                            clean build artifactacts for a package (gxpkg clean)")
   (displayln "  pkg                              invoke the gerbil package manager (gxpkg)")
   (displayln "  test                             run tests (gxtest)")


### PR DESCRIPTION
This addresses the global-vs-local state madness with .gerbil:
When we are in local package context, we create a new local .gerbil to use for the build, which gives us isolation.
We also create manifests for all the individual packages, so that we can get meaningful error reports.

On top of #916.
See also #651 