### PR TITLE
Fix broken http condition def and http-response-write-condition api

### DIFF
--- a/src/std/net/httpd/handler.ss
+++ b/src/std/net/httpd/handler.ss
@@ -628,7 +628,7 @@ END-C
                       (string-substitute-char (stx-e #'message-string) #\- #\space)))))
        #'(begin
            (def condition
-             (make-http-condition code (quote message)))
+             (make-http-condition code (quote message-string)))
            (export condition)
            (hash-put! +http-response-codes+ code (quote message-string)))))))
 

--- a/src/std/net/httpd/handler.ss
+++ b/src/std/net/httpd/handler.ss
@@ -615,15 +615,27 @@ END-C
         ("OPTIONS" 'OPTIONS)))
 
 (def +http-response-codes+ (make-hash-table-eq))
+
 (defstruct http-condition (code message))
-(defrule (def-http-condition ctx code message)
-  (with-id ctx ((condition
-                 (string-substitute-char (stringify #'message) #\- #\space)))
-    (def condition (make-http-condition code message))
-    (export condition)
-    (hash-put! +http-response-codes+ code message)))
+
+(defsyntax (def-http-condition stx)
+  (syntax-case stx ()
+    ((_ code message-string)
+     (stx-string? #'message-string)
+     (with-syntax ((condition
+                    (syntax-local-introduce
+                     (make-symbol
+                      (string-substitute-char (stx-e #'message-string) #\- #\space)))))
+       #'(begin
+           (def condition
+             (make-http-condition code (quote message)))
+           (export condition)
+           (hash-put! +http-response-codes+ code (quote message-string)))))))
+
 (defrules def-http-conditions ()
-  ((ctx (number message) ...) (begin (def-http-condition ctx number message) ...)))
+  ((_ (number message) ...)
+   (begin (def-http-condition number message) ...)))
+
 (def-http-conditions
   (100 "Continue")
   (101 "Switching Protocols")
@@ -666,8 +678,10 @@ END-C
   (504 "Gateway Timeout")
   (505 "HTTP Version Not Supported"))
 
-(def (http-response-write-condition
-      res (condition #f) code: (code #f) content-type: (content-type #f) message: (message #f))
+(def (http-response-write-condition res (condition #f)
+                                    code: (code #f)
+                                    content-type: (content-type #f)
+                                    message: (message #f))
   (http-response-write res (or code (http-condition-code condition))
                        `(("Content-Type" . ,(or content-type "text/plain")))
                        (or message (http-condition-message condition))))

--- a/src/std/net/httpd/handler.ss
+++ b/src/std/net/httpd/handler.ss
@@ -618,7 +618,7 @@ END-C
 
 (defstruct http-condition (code message))
 
-(defsyntax (def-http-condition stx)
+(defsyntax (defhttp-condition stx)
   (syntax-case stx ()
     ((_ code message-string)
      (stx-string? #'message-string)
@@ -632,11 +632,11 @@ END-C
            (export condition)
            (hash-put! +http-response-codes+ code (quote message-string)))))))
 
-(defrules def-http-conditions ()
+(defrules defhttp-conditions ()
   ((_ (number message) ...)
-   (begin (def-http-condition number message) ...)))
+   (begin (defhttp-condition number message) ...)))
 
-(def-http-conditions
+(defhttp-conditions
   (100 "Continue")
   (101 "Switching Protocols")
   (200 "OK")

--- a/src/std/net/httpd/handler.ss
+++ b/src/std/net/httpd/handler.ss
@@ -678,13 +678,10 @@ END-C
   (504 "Gateway Timeout")
   (505 "HTTP Version Not Supported"))
 
-(def (http-response-write-condition res (condition #f)
-                                    code: (code #f)
-                                    content-type: (content-type #f)
-                                    message: (message #f))
-  (http-response-write res (or code (http-condition-code condition))
-                       `(("Content-Type" . ,(or content-type "text/plain")))
-                       (or message (http-condition-message condition))))
+(def (http-response-write-condition res condition)
+  (http-response-write res (http-condition-code condition)
+                       `(("Content-Type" . "text/plain"))
+                       (http-condition-message condition)))
 
 (def (condition-handler handler)
   (lambda (req res)


### PR DESCRIPTION
def-http-condition was _broken_; the working build was failing haphazardly with 
```
*** ERROR IN #:loop97259, "misc/concurrent-plan.ss"@88.7 -- Build Failure at net/httpd/server

*** ERROR IN ?
--- Syntax Error: Bad syntax; not a syntax binding
... form:   message
```

It was infrequent enough that I treated as an annoyance, but I had it happen quite a few times today, so I fixed it.

Also fixes the `http-response-write-condition` api which was also _terminally broken_.
It would simply crash without passing any parameters.

@fare please be careful with such things in the future, the handler is using `(not safe)` at module level.