### PR TITLE
Define gerbil-path

### DIFF
--- a/src/gerbil/compiler/driver.ss
+++ b/src/gerbil/compiler/driver.ss
@@ -6,10 +6,15 @@ namespace: gxc
 
 (import :gerbil/expander
         :gerbil/gambit
+        (only-in :gerbil/runtime gerbil-path)
         "base"
         "compile"
         "optimize")
 (export compile-module compile-exe)
+
+(def (gerbil-path) ;; definition needed here until it is in the bootstrapped runtime
+  (or (getenv "GERBIL_PATH" #f)
+      (path-expand "~/.gerbil")))
 
 (def default-gerbil-gsc
   (path-expand "gsc" (path-expand "bin" (path-expand "~~"))))
@@ -139,7 +144,7 @@ namespace: gxc
            (base (string-append "-I " gerbil-staticdir))
            (user-static-dir
             (path-expand
-             (path-expand "lib/static" (getenv "GERBIL_PATH" "~/.gerbil"))))
+             (path-expand "lib/static" (gerbil-path))))
            (base (string-append base " -I " user-static-dir)))
       [base ... (gsc-cc-options) ...]))
 
@@ -296,7 +301,7 @@ namespace: gxc
       (path-expand "static" libdir))
     (def user-static-dir
       (path-expand
-       (path-expand "lib/static" (getenv "GERBIL_PATH" "~/.gerbil"))))
+       (path-expand "lib/static" (gerbil-path))))
     (def cppflags
       (string-append "-I " static-dir " -I " user-static-dir))
 

--- a/src/gerbil/compiler/driver.ss
+++ b/src/gerbil/compiler/driver.ss
@@ -6,15 +6,12 @@ namespace: gxc
 
 (import :gerbil/expander
         :gerbil/gambit
-        (only-in :gerbil/runtime gerbil-path)
         "base"
         "compile"
         "optimize")
 (export compile-module compile-exe)
 
-(def (gerbil-path) ;; definition needed here until it is in the bootstrapped runtime
-  (or (getenv "GERBIL_PATH" #f)
-      (path-expand "~/.gerbil")))
+(extern namespace: #f gerbil-path) ;; needed until bootstrap re-generated
 
 (def default-gerbil-gsc
   (path-expand "gsc" (path-expand "bin" (path-expand "~~"))))

--- a/src/gerbil/gxc-main.ss
+++ b/src/gerbil/gxc-main.ss
@@ -25,7 +25,7 @@
   (displayln " -gsc-option <opt> <string>  add [<opt> <string>] to gsc options"))
 
 (def (gxc-parse-args args)
-  (def outdir (path-expand "lib" (getenv "GERBIL_PATH" "~/.gerbil")))
+  (def outdir (path-expand "lib" (gerbil-path)))
   (def invoke-gsc #t)
   (def keep-scm #f)
   (def verbose #f)

--- a/src/gerbil/main.ss
+++ b/src/gerbil/main.ss
@@ -10,9 +10,7 @@ package: gerbil
 (include "gxi-main.ss")
 (include "gxc-main.ss")
 
-(def (gerbil-path) ;; definition needed here until it is in the bootstrapped runtime
-  (or (getenv "GERBIL_PATH" #f)
-      (path-expand "~/.gerbil")))
+(extern namespace: #f gerbil-path) ;; needed until bootstrap re-generated
 
 (def builtin-modules
   '(;; :gerbil/runtime

--- a/src/gerbil/main.ss
+++ b/src/gerbil/main.ss
@@ -10,6 +10,10 @@ package: gerbil
 (include "gxi-main.ss")
 (include "gxc-main.ss")
 
+(def (gerbil-path) ;; definition needed here until it is in the bootstrapped runtime
+  (or (getenv "GERBIL_PATH" #f)
+      (path-expand "~/.gerbil")))
+
 (def builtin-modules
   '(;; :gerbil/runtime
     "gerbil/runtime/gambit"

--- a/src/gerbil/prelude/core.ss
+++ b/src/gerbil/prelude/core.ss
@@ -279,6 +279,8 @@ package: gerbil
     gerbil-load-expander!
     ;; our home
     gerbil-home
+    ;; path to which to compile modules and from which to load them
+    gerbil-path
 
     ;; concurrency primitives
     spawn spawn/name spawn/group spawn-actor spawn-thread

--- a/src/gerbil/runtime/init.ss
+++ b/src/gerbil/runtime/init.ss
@@ -238,6 +238,10 @@ namespace: #f
      (else
       (gx#core-eval-module obj)))))
 
+(def (gerbil-path)
+  (or (getenv "GERBIL_PATH" #f)
+      (path-expand "~/.gerbil")))
+
 (def (gerbil-runtime-init! builtin-modules)
   ;; initialize the load path
   (let* ((home (gerbil-home))
@@ -250,7 +254,7 @@ namespace: #f
                          (string-split envvar #\:))))
            (else '())))
          (userpath
-          (path-expand "lib" (getenv "GERBIL_PATH" "~/.gerbil")))
+          (path-expand "lib" (gerbil-path)))
          (loadpath
           (if (getenv "GERBIL_BUILD_PREFIX" #f)
             loadpath

--- a/src/gerbil/runtime/init.ss
+++ b/src/gerbil/runtime/init.ss
@@ -238,10 +238,6 @@ namespace: #f
      (else
       (gx#core-eval-module obj)))))
 
-(def (gerbil-path)
-  (or (getenv "GERBIL_PATH" #f)
-      (path-expand "~/.gerbil")))
-
 (def (gerbil-runtime-init! builtin-modules)
   ;; initialize the load path
   (let* ((home (gerbil-home))

--- a/src/gerbil/runtime/system.ss
+++ b/src/gerbil/runtime/system.ss
@@ -5,6 +5,7 @@ prelude: :gerbil/core
 package: gerbil/runtime
 namespace: #f
 
+(export #t)
 (import "gambit" "util")
 (include "version.ss")
 
@@ -20,6 +21,10 @@ namespace: #f
 
 (def (gerbil-home)
   (getenv "GERBIL_HOME" (path-expand "~~")))
+
+(def (gerbil-path)
+  (or (getenv "GERBIL_PATH" #f)
+      (path-expand "~/.gerbil")))
 
 (def (gerbil-runtime-smp?)
   (member "--enable-smp" (string-split (configure-command-string) #\')))

--- a/src/std/actor-v18/loader-test-server.ss
+++ b/src/std/actor-v18/loader-test-server.ss
@@ -25,4 +25,4 @@ package: test/actor-v18
          (start-loader!))
 
        (thread-join! srv)))
-   (path-expand "lib" (getenv "GERBIL_PATH"))))
+   (path-expand "lib" (gerbil-path))))

--- a/src/std/actor-v18/path.ss
+++ b/src/std/actor-v18/path.ss
@@ -2,7 +2,6 @@
 ;;; © vyzo
 ;;; ensemble path utils
 (export #t)
-(import (only-in :gerbil/runtime gerbil-path))
 
 (def (ensemble-base-path)
   (path-expand "ensemble" (gerbil-path)))

--- a/src/std/actor-v18/path.ss
+++ b/src/std/actor-v18/path.ss
@@ -2,10 +2,10 @@
 ;;; © vyzo
 ;;; ensemble path utils
 (export #t)
+(import (only-in :gerbil/runtime gerbil-path))
 
 (def (ensemble-base-path)
-  (path-expand
-   (path-expand "ensemble" (getenv "GERBIL_PATH" "~/.gerbil"))))
+  (path-expand "ensemble" (gerbil-path)))
 
 (def (ensemble-server-path server-id)
   (path-expand (symbol->string server-id)

--- a/src/std/make.ss
+++ b/src/std/make.ss
@@ -6,7 +6,6 @@
 (import :gerbil/compiler
         :gerbil/expander
         :gerbil/gambit
-        (only-in :gerbil/runtime gerbil-path)
         ./srfi/1
         ./misc/hash
         ./misc/list

--- a/src/std/make.ss
+++ b/src/std/make.ss
@@ -6,6 +6,7 @@
 (import :gerbil/compiler
         :gerbil/expander
         :gerbil/gambit
+        (only-in :gerbil/runtime gerbil-path)
         ./srfi/1
         ./misc/hash
         ./misc/list
@@ -104,10 +105,10 @@ TODO:
       build-release: (build-release #f)
       build-optimized: (build-optimized #f))
 
-    (def gerbil-path (getenv "GERBIL_PATH" "~/.gerbil"))
+    (def gerbil-path_ (delay (gerbil-path)))
     (def srcdir (or srcdir_ (error "srcdir must be specified")))
-    (def libdir (or libdir_ (path-expand "lib" gerbil-path)))
-    (def bindir (or bindir_ (path-expand "bin" gerbil-path)))
+    (def libdir (or libdir_ (path-expand "lib" (force gerbil-path_))))
+    (def bindir (or bindir_ (path-expand "bin" (force gerbil-path_))))
     (def prefix (or prefix_ (read-package-prefix srcdir)))
     (def libdir-prefix (if prefix (path-expand prefix libdir) libdir))
     (def build-deps (path-expand (or build-deps_ "build-deps") srcdir))

--- a/src/tools/gxensemble.ss
+++ b/src/tools/gxensemble.ss
@@ -2,7 +2,6 @@
 ;;; © vyzo
 ;;; actor ensemble management tool
 (import :gerbil/expander
-        (only-in :gerbil/runtime gerbil-path)
         :std/sugar
         :std/iter
         :std/getopt

--- a/src/tools/gxensemble.ss
+++ b/src/tools/gxensemble.ss
@@ -2,6 +2,7 @@
 ;;; © vyzo
 ;;; actor ensemble management tool
 (import :gerbil/expander
+        (only-in :gerbil/runtime gerbil-path)
         :std/sugar
         :std/iter
         :std/getopt
@@ -547,7 +548,6 @@
   (let* ((server-id (hash-ref opt 'server-id))
          (output    (hash-ref opt 'output))
          (output    (path-expand output (current-directory)))
-         (gerbil-path (getenv "GERBIL_PATH" "~/.gerbil"))
          (ensemble-base "ensemble/")
          (ensemble-rebase
           (lambda files
@@ -560,7 +560,7 @@
           (lambda files
             (map (cut string-append server-base <>) files))))
 
-    (current-directory gerbil-path)
+    (current-directory (gerbil-path))
     (invoke "tar"
             ["cavf" output
              (ensemble-rebase

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -23,7 +23,6 @@
 ;;; TODO: add private repos support
 
 (import :gerbil/gambit
-        (only-in :gerbil/runtime gerbil-path)
         :std/getopt
         :std/sugar
         :std/iter

--- a/src/tools/gxpkg.ss
+++ b/src/tools/gxpkg.ss
@@ -23,6 +23,7 @@
 ;;; TODO: add private repos support
 
 (import :gerbil/gambit
+        (only-in :gerbil/runtime gerbil-path)
         :std/getopt
         :std/sugar
         :std/iter
@@ -307,7 +308,7 @@
 
 ;;; action implementation -- script api
 (def +root-dir+
-  (delay (getenv "GERBIL_PATH" "~/.gerbil")))
+  (delay (gerbil-path)))
 (def +pkg-root-dir+
   (delay (path-expand "pkg" (force +root-dir+))))
 (def +pkg-lib-dir+
@@ -783,7 +784,7 @@
   (path-expand "pkg/directory-list" (path-expand "~/.gerbil")))
 
 (def (pkg-directory-local-dirs-path)
-  (path-expand "pkg/directory-list" (path-expand (getenv "GERBIL_PATH" "~/.gerbil"))))
+  (path-expand "pkg/directory-list" (gerbil-path)))
 
 (def (pkg-directory-dirs)
   (let* ((user-dir (pkg-directory-user-dirs-path))


### PR DESCRIPTION
Defines `(gerbil-path)` in the runtime so that we don't have to `getenv` it right and left.