### PR TITLE
`link` element no longer has closing html tag

### DIFF
--- a/src/std/xml-test.ss
+++ b/src/std/xml-test.ss
@@ -1,0 +1,31 @@
+(export xml-test)
+
+(import :std/test :std/xml)
+
+(def xml-test
+  (test-suite "test :std/xml"
+    (test-case "converting elements from sxml to html"
+      ; normal elements with children include a closing tag
+      (check-output (print-sxml->html*
+        '(*TOP*
+          (div
+            (p "I'm paragraph one")
+            (p "I'm paragraph two"))))
+        "<div><p>I'm paragraph one</p><p>I'm paragraph two</p></div>")
+
+      ; void elements must never include a closing tag
+      (check-output (print-sxml->html*
+        '(*TOP*
+          (area)
+          (base)
+          (br)
+          (col)
+          (embed)
+          (hr)
+          (img)
+          (input)
+          (link)
+          (meta)
+          (track)
+          (wbr)))
+        "<area><base><br><col><embed><hr><img><input><link><meta><track><wbr>"))))

--- a/src/std/xml/sxml-to-xml.scm
+++ b/src/std/xml/sxml-to-xml.scm
@@ -502,7 +502,7 @@
                                    (@char>> #\/ port)))
                         (@char>> #\> port))))
           (cond ((or (pair? content)
-                     (memq nam '(iframe div span textarea link script style ul))) ; For XHTML support
+                     (memq nam '(iframe div span textarea script style ul))) ; For XHTML support
                  (out>>/body>> (body->>> content))) ;; first I called it body->>> body>>/body. that would be sick
                 ((null? content)
                  (end>>))


### PR DESCRIPTION
closes #958