### PR TITLE
Disable flaky signal tests

### DIFF
--- a/src/std/os/signal-00-signalfd-test.ss
+++ b/src/std/os/signal-00-signalfd-test.ss
@@ -1,25 +1,26 @@
 ;;; -*- Gerbil -*-
 ;;; (C) vyzo at hackzen.org
 ;;; :std/os/signalfd unit-test
+(cond-expand
+  (enable-signalfd-test
+   (import :std/test
+           ./signal
+           ./signalfd
+           ./pid)
+   (export signalfd-test)
 
-(import :std/test
-        ./signal
-        ./signalfd
-        ./pid)
-(export signalfd-test)
+   (def signalfd-test
+     (test-suite "signalfd"
+       (test-case "basic signal handling"
+         (def ss (make_sigset))
+         (sigaddset ss SIGHUP)
+         (sigprocmask SIG_BLOCK ss #f)
+         (def sfd (signalfd ss))
 
-(def signalfd-test
-  (test-suite "signalfd"
-    (test-case "basic signal handling"
-      (def ss (make_sigset))
-      (sigaddset ss SIGHUP)
-      (sigprocmask SIG_BLOCK ss #f)
-      (def sfd (signalfd ss))
+         (spawn
+          (lambda ()
+            (thread-sleep! 1)
+            (kill (getpid) SIGHUP)))
 
-      (spawn
-       (lambda ()
-         (thread-sleep! 1)
-         (kill (getpid) SIGHUP)))
-
-      (let (r (signalfd-read sfd))
-        (check (signalfd-siginfo-signo r) => SIGHUP)))))
+         (let (r (signalfd-read sfd))
+           (check (signalfd-siginfo-signo r) => SIGHUP)))))))

--- a/src/std/os/signal-01-signal-handler-test.ss
+++ b/src/std/os/signal-01-signal-handler-test.ss
@@ -2,39 +2,41 @@
 ;;; (C) vyzo at hackzen.org
 ;;; :std/os/signal-handler unit-test
 
-(import :std/test
-        :std/sugar
-        ./signal
-        ./signal-handler
-        ./pid)
+(cond-expand
+  (enable-signal-test
+   (import :std/test
+           :std/sugar
+           ./signal
+           ./signal-handler
+           ./pid)
 
-(export signal-handler-test)
-(def signal-handler-test
-  (test-suite "signal-handler"
-    (test-case "basic signal handling"
-      ;; drain the message queue first from possible garbage from other tests
-      (while (thread-receive 0 #f))
+   (export signal-handler-test)
+   (def signal-handler-test
+     (test-suite "signal-handler"
+       (test-case "basic signal handling"
+         ;; drain the message queue first from possible garbage from other tests
+         (while (thread-receive 0 #f))
 
-      (add-signal-handler!
-       SIGHUP
-       (let (thread (current-thread))
-         (lambda ()
-           (thread-send thread SIGHUP))))
-      (add-signal-handler!
-       SIGUSR1
-       (let (thread (current-thread))
-         (lambda ()
-           (thread-send thread SIGUSR1))))
+         (add-signal-handler!
+          SIGHUP
+          (let (thread (current-thread))
+            (lambda ()
+              (thread-send thread SIGHUP))))
+         (add-signal-handler!
+          SIGUSR1
+          (let (thread (current-thread))
+            (lambda ()
+              (thread-send thread SIGUSR1))))
 
-      (spawn
-       (lambda ()
-         (thread-sleep! 1)
-         (kill (getpid) SIGHUP)
-         (thread-sleep! 1)
-         (kill (getpid) SIGUSR1)
-         (thread-sleep! 1)
-         (kill (getpid) SIGHUP)))
+         (spawn
+          (lambda ()
+            (thread-sleep! 1)
+            (kill (getpid) SIGHUP)
+            (thread-sleep! 1)
+            (kill (getpid) SIGUSR1)
+            (thread-sleep! 1)
+            (kill (getpid) SIGHUP)))
 
-      (check (thread-receive) => SIGHUP)
-      (check (thread-receive) => SIGUSR1)
-      (check (thread-receive) => SIGHUP))))
+         (check (thread-receive) => SIGHUP)
+         (check (thread-receive) => SIGUSR1)
+         (check (thread-receive) => SIGHUP))))))


### PR DESCRIPTION
They tend to fail once every few runs, which may block prs of unrelated functionality.