### PR TITLE
Install fixes for MacOS (and remove the extra v)

### DIFF
--- a/configure
+++ b/configure
@@ -57,7 +57,7 @@ package_out_of_tree() {
     echo "It is now available as an external package: github.com/mighty-gerbils/gerbil-${pkg}"
 }
 
-readonly gerbil_version="v$(git describe --tags --always)"
+readonly gerbil_version="$(git describe --tags --always)"
 readonly gerbil_targets=""
 readonly default_gambit_tag=24201248effa23d5017be4992b5b9879e4cd3a4c
 readonly default_gambit_config="--enable-targets=${gerbil_targets} --enable-single-host --enable-dynamic-clib --enable-default-runtime-options=tE8,f8,-8 --enable-trust-c-tco"

--- a/homebrew/README.org
+++ b/homebrew/README.org
@@ -169,6 +169,7 @@ Now the things it depends on.
   depends_on "sqlite"
   depends_on "zlib"
   depends_on "gcc"
+  depends_on "findutils"
 
   fails_with :clang do
     cause "gerbil-scheme is built with GCC"

--- a/homebrew/gerbil-scheme.rb
+++ b/homebrew/gerbil-scheme.rb
@@ -11,6 +11,7 @@ class GerbilScheme < Formula
   depends_on "sqlite"
   depends_on "zlib"
   depends_on "gcc"
+  depends_on "findutils"
 
   fails_with :clang do
     cause "gerbil-scheme is built with GCC"

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,14 @@ die() {
   exit 1
 }
 
+if [ $(uname) = "Darwin" ];
+then
+    FIND=gfind
+else
+    FIND=find
+fi
+
+
 install() {
     local prefix="${1}"
     mkdir -p "${prefix}" || die
@@ -40,7 +48,7 @@ install_src_files() {
     local dest="${2}"
     local oldpwd="$(pwd)"
     cd "${src}"
-    for f in $(find -name \*.ss -or -name \*.ssi -or -name \*.scm -or -name \*.c | egrep -v "/[.]gerbil" | grep -v build.ss); do
+    for f in $(${FIND} -name \*.ss -or -name \*.ssi -or -name \*.scm -or -name \*.c | egrep -v "/[.]gerbil" | grep -v build.ss); do
         mkdir -p $(dirname "${dest}/${f}") || die
         cp -v "${f}" "${dest}/${f}" || die
     done


### PR DESCRIPTION
MacOS did not have a find argument that was used in installl.sh. Added `gfind` to the recipe and modified the install. 

Also removed the extra v as I got sick of `/opt/homebrew/Cellar/gerbil-scheme/0.18/vv0.18-rc1/lib/std/xml__rt.o1`

If we plan to tag without a v we can put it back. 