### PR TITLE
A couple of fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ src/TAGS
 .build*
 doc/node_modules
 doc/.vuepress/dist
-# src/gerbil/runtime/version.ss
+src/gerbil/runtime/version.ss
 src/gerbil/boot-gxi
 src/bootstrap/static
 

--- a/src/gerbil/runtime/init.ss
+++ b/src/gerbil/runtime/init.ss
@@ -254,9 +254,9 @@ namespace: #f
             (path-expand "lib" (gerbil-path)))
            (loadpath
             (if (getenv "GERBIL_BUILD_PREFIX" #f)
-              loadpath
-              (cons userpath loadpath))))
-      (current-module-library-path (cons libdir loadpath)))
+              (cons loadpath libdir)
+              (cons* loadpath userpath libdir))))
+      (current-module-library-path loadpath))
 
     ;; initialize the modue registry
     (let* ((registry-entry (lambda (m) (cons m 'builtin)))

--- a/src/gerbil/runtime/init.ss
+++ b/src/gerbil/runtime/init.ss
@@ -243,19 +243,21 @@ namespace: #f
     ;; initialize the load path
     (let* ((home (gerbil-home))
            (libdir (path-expand "lib" home))
-           (loadpath
-            (cond
-             ((getenv "GERBIL_LOADPATH" #f)
-              => (lambda (envvar)
-                   (filter (lambda (x) (not (string-empty? x)))
-                           (string-split envvar #\:))))
-             (else '())))
            (userpath
             (path-expand "lib" (gerbil-path)))
            (loadpath
             (if (getenv "GERBIL_BUILD_PREFIX" #f)
-              (cons loadpath libdir)
-              (cons* loadpath userpath libdir))))
+              [libdir]
+              [userpath libdir]))
+           (loadpath
+            (cond
+             ((getenv "GERBIL_LOADPATH" #f)
+              => (lambda (envvar)
+                   (append
+                    (filter (lambda (x) (not (string-empty? x)))
+                            (string-split envvar #\:))
+                    loadpath)))
+             (else loadpath))))
       (current-module-library-path loadpath))
 
     ;; initialize the modue registry

--- a/src/gerbil/runtime/version.ss
+++ b/src/gerbil/runtime/version.ss
@@ -1,1 +1,0 @@
-(def (gerbil-version-string) "v0.18")

--- a/src/std/make.ss
+++ b/src/std/make.ss
@@ -513,8 +513,9 @@ TODO:
     (lambda (spec)
       (for-each
         (lambda (f)
-          (displayln "... remove " f)
-          (delete-file-or-directory f))
+          (when (file-exists? f)
+            (displayln "... remove " f)
+            (delete-file-or-directory f)))
         (spec-outputs spec settings)))
     buildspec))
 


### PR DESCRIPTION
0. Kill version.ss, the v0.19 development cycle has started.
1. make clean should not try to delete things that don't exist and fail
2. normalize load-path order: 1. GERBIL_LOADPATH 2. GERBIL_PATH/lib 3. GERBIL_HOME/lib (2 is excluded during the build)