### PR TITLE
Makefile: add build to .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ clean:
 	rm -rf bootstrap
 	cd src/gambit && make clean
 
-.PHONY: all install check clean
+.PHONY: all build install check clean


### PR DESCRIPTION
When the `build` directory exists, the build target needs to be in .PHONY, such that make would consider remaking `build`.