### PR TITLE
Fix typo

### DIFF
--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -93,7 +93,7 @@ add_path() {
     fi
 }
 
-GERBIL_INSTAL_PREFIX=/usr/local/gerbil # no need to export this
+GERBIL_INSTALL_PREFIX=/usr/local/gerbil # no need to export this
 add_path $GERBIL_INSTALL_PREFIX/bin
 add_path $HOME/.gerbil/bin
 ```


### PR DESCRIPTION
I noticed a small typo in the updated Shell Config section of the documentation.