### PR TITLE
fix build on gcc 10

### DIFF
--- a/src/std/net/ssl/libssl.ss
+++ b/src/std/net/ssl/libssl.ss
@@ -79,7 +79,7 @@ static ___SCMOBJ ffi_ssl_error(SSL *ssl, int r)
    return ___CHR(119);
   case SSL_ERROR_ZERO_RETURN:
    return ___FIX(0);
-   default:
+   default: {
    ___processor_state ___ps = ___GET_PSTATE();
    ___SCMOBJ result = ___make_pair(___ps, ___FIX(last), ___NUL);
    ___release_scmobj(result);
@@ -88,6 +88,7 @@ static ___SCMOBJ ffi_ssl_error(SSL *ssl, int r)
    result = ___make_pair(___ps, ___FIX(r), result);
    ___release_scmobj(result);
    return result;
+   }
  }
 }
 


### PR DESCRIPTION
Fixes compilation under:

gcc --version

    gcc (Ubuntu 10.5.0-1ubuntu1~20.04) 10.5.0

uname -ovm

    #98~20.04.1-Ubuntu SMP Mon Oct 9 16:43:45 UTC 2023 x86_64 GNU/Linux
