### PR TITLE
gxtags: fix use of ##locat-position

### DIFF
--- a/src/tools/gxtags.ss
+++ b/src/tools/gxtags.ss
@@ -261,7 +261,7 @@
 
 (def (source-location-line locat)
   (if (##locat? locat)
-    (let (filepos (##position->filepos (##locat-position locat)))
+    (let (filepos (##position->filepos (##locat-start-position locat)))
       (fx1+ (##filepos-line filepos)))
     1))
 


### PR DESCRIPTION
As of
https://github.com/gambit/gambit/commit/556a884d40f7e87cce54ff49c514c44a79bc311c global ##locat-start-position should be used instead of ##locat-position.