### PR TITLE
std/srfi/128: comparator-if<=> should use make-default-comparator

### DIFF
--- a/src/std/srfi/128.ss
+++ b/src/std/srfi/128.ss
@@ -319,4 +319,4 @@
          equal
          greater))))
   ((recur o1 o2 less equal greater)
-   (recur (default-comparator) o1 o2 less equal greater)))
+   (recur (make-default-comparator) o1 o2 less equal greater)))


### PR DESCRIPTION
`default-comparator` is not defined.