### PR TITLE
Docs: 404 links, `generic.md` headlines, misc

### DIFF
--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -159,7 +159,7 @@ At this point we have a new project template, which is ready to build
 and is waiting for you to fill your code.
 
 The tool has created the following files in the current directory:
-- `gerbil.pkg` -- this includes project meta-data, the most important being the package namesace.
+- `gerbil.pkg` -- this includes project meta-data, the most important being the package namespace.
   As we can see, this is my `vyzo` user name in this example
 - `build.ss` -- this is the project build script, pre-filled with the two source files the
   tool generated.

--- a/doc/reference/gerbil/prelude/core-expander-syntax.md
+++ b/doc/reference/gerbil/prelude/core-expander-syntax.md
@@ -4,26 +4,30 @@ Gerbil is a Meta-Scheme that bases the expansion of forms on the
 context present while expanding.
 When expanded by the compiler or interpreter a form could have very
 different meanings depending on the
-[current-expander-context](/reference/core-expander.html#current-expander-context).
-
+[current-expander-context](/reference/gerbil/expander/#current-expander-context).
 
 These syntactic forms come from the root context, which is the parent context
 of all syntactic contexts in Gerbil. They are not a part of the core prelude
 per se, but they are documented here for completeness.
 
 ## Top Forms
+
 ### begin
+
 ``` scheme
 (begin form ....)
 ```
 
 ### begin-syntax
+
 ``` scheme
 (begin-syntax form ...)
 ```
+
 Like begin, but at syntax phase `phi +1`.
 
 ### begin-annotation
+
 ``` scheme
 (begin-annotation annotation form ...)
 ```
@@ -32,6 +36,7 @@ Effect the declarations in `annotation` in the scope of the body.
 Not implemented yet.
 
 ### import
+
 ``` scheme
 (import import-spec ...)
 
@@ -60,6 +65,7 @@ Not implemented yet.
 Imports bindings to the current syntactic context. Must appear at top or module context.
 
 ### module
+
 ``` scheme
 (module id module-body ...)
 ```
@@ -68,6 +74,7 @@ Creates a module and binds it to `id`. The module may be defined at top context 
 a top module or as a nested module inside another module.
 
 ### export
+
 ``` scheme
 (export export-spec ...)
 
@@ -85,6 +92,7 @@ a top module or as a nested module inside another module.
 Exports bindings from the current module.
 
 ### declare
+
 ``` scheme
 (declare declaration ...)
 ```
@@ -92,6 +100,7 @@ Exports bindings from the current module.
 Make declarations that the compiler finds useful
 
 ### include
+
 ``` scheme
 (include path)
 ```
@@ -99,13 +108,14 @@ Make declarations that the compiler finds useful
 Include the contents of path, wrapped with a `begin`.
 
 ### cond-expand
+
 ``` scheme
 (cond-expand
  (feature body ...) ...
  [(else body ...)])
 
 <feature>:
- (and feature ...)             ; boolean and of `feature ...`
+ (and feature ...)            ; boolean and of `feature ...`
  (or feature ...)             ; boolean or of `feature ...`
  (not feature)                ; negation of feature
  id                           ; satisfied if `id` is bound as an identifier
@@ -114,6 +124,7 @@ Include the contents of path, wrapped with a `begin`.
 Conditionally expands the body for the first satisfied feature. Must appear at top scope.
 
 ### provide
+
 ``` scheme
 (provide id ...)
 ```
@@ -121,16 +132,19 @@ Conditionally expands the body for the first satisfied feature. Must appear at t
 Binds `id ...` as features provided by a module.
 
 ### define-values
+
 ``` scheme
 (define-values (id ...) expr)
 ```
 
 ### define-syntax
+
 ``` scheme
 (define-syntax id expr)
 ```
 
 ### define-alias
+
 ``` scheme
 (define-alias id alias-id)
 ```
@@ -138,6 +152,7 @@ Binds `id ...` as features provided by a module.
 Defines a syntactic alias for `id` to be the same as `alias-id`
 
 ### extern
+
 ``` scheme
 (extern id ...)
 (extern namespace: [namespace-id | #f] id ...)
@@ -147,7 +162,9 @@ Create runtime bindings for `id`, with the symbols bound at runtime through an
 external mechanism (eg builtin or defined at a foreign library).
 
 ## Expressions
+
 ### lambda%
+
 ``` scheme
 (lambda% lambda-formals body ...)
 ```
@@ -155,11 +172,13 @@ external mechanism (eg builtin or defined at a foreign library).
 Plain old Scheme `lambda`, without optional and keyword argument support
 
 ### case-lambda
+
 ``` scheme
 (case-lambda (lambda-formals body ...) ...)
 ```
 
-### let-values letrec-values letrec*-values
+### let-values letrec-values letrec\*-values
+
 ``` scheme
 (let-values (((id ...) expr) ...) body ...)
 (letrec-values (((id ...) expr) ...) body ...)
@@ -167,23 +186,27 @@ Plain old Scheme `lambda`, without optional and keyword argument support
 ```
 
 ### let-syntax letrec-syntax
+
 ``` scheme
 (let-syntax ((id syntax-expr) ...) body ...)
 (letrec-syntax ((id syntax-expr) ...) body ...)
 ```
 
 ### if
+
 ``` scheme
 (if test-expr then-expr else-expr)
 (if test-expr then-expr)
 ```
 
 ### quote
+
 ``` scheme
 (quote datum)
 ```
 
 ### quote-syntax
+
 ``` scheme
 (quote-syntax id)
 ```
@@ -191,16 +214,19 @@ Plain old Scheme `lambda`, without optional and keyword argument support
 Quote an identifier `id`, capturing its syntactic context.
 
 ## Expander Hooks
+
 ```
 (%%app rator rand ...)
 (%%ref id)
 (%%begin-module body ...)
 ```
+
 Special expander indirection hooks; explained elsewhere in the documentation.
 
 ## Reserved Syntactic Tokens
+
 The following widely used syntactic tokens are defined as reserved expanders:
+
 ```
 _ ... else => unquote unquote-splicing unsyntax unsyntax-splicing
 ```
-

--- a/doc/reference/gerbil/prelude/core-expander-syntax.md
+++ b/doc/reference/gerbil/prelude/core-expander-syntax.md
@@ -6,6 +6,7 @@ When expanded by the compiler or interpreter a form could have very
 different meanings depending on the
 [current-expander-context](/reference/gerbil/expander/#current-expander-context).
 
+
 These syntactic forms come from the root context, which is the parent context
 of all syntactic contexts in Gerbil. They are not a part of the core prelude
 per se, but they are documented here for completeness.
@@ -20,7 +21,6 @@ per se, but they are documented here for completeness.
 ``` scheme
 (begin-syntax form ...)
 ```
-
 Like begin, but at syntax phase `phi +1`.
 
 ### begin-annotation
@@ -196,7 +196,6 @@ Quote an identifier `id`, capturing its syntactic context.
 (%%ref id)
 (%%begin-module body ...)
 ```
-
 Special expander indirection hooks; explained elsewhere in the documentation.
 
 ## Reserved Syntactic Tokens

--- a/doc/reference/gerbil/prelude/core-expander-syntax.md
+++ b/doc/reference/gerbil/prelude/core-expander-syntax.md
@@ -11,15 +11,12 @@ of all syntactic contexts in Gerbil. They are not a part of the core prelude
 per se, but they are documented here for completeness.
 
 ## Top Forms
-
 ### begin
-
 ``` scheme
 (begin form ....)
 ```
 
 ### begin-syntax
-
 ``` scheme
 (begin-syntax form ...)
 ```
@@ -27,7 +24,6 @@ per se, but they are documented here for completeness.
 Like begin, but at syntax phase `phi +1`.
 
 ### begin-annotation
-
 ``` scheme
 (begin-annotation annotation form ...)
 ```
@@ -36,7 +32,6 @@ Effect the declarations in `annotation` in the scope of the body.
 Not implemented yet.
 
 ### import
-
 ``` scheme
 (import import-spec ...)
 
@@ -65,7 +60,6 @@ Not implemented yet.
 Imports bindings to the current syntactic context. Must appear at top or module context.
 
 ### module
-
 ``` scheme
 (module id module-body ...)
 ```
@@ -74,7 +68,6 @@ Creates a module and binds it to `id`. The module may be defined at top context 
 a top module or as a nested module inside another module.
 
 ### export
-
 ``` scheme
 (export export-spec ...)
 
@@ -92,7 +85,6 @@ a top module or as a nested module inside another module.
 Exports bindings from the current module.
 
 ### declare
-
 ``` scheme
 (declare declaration ...)
 ```
@@ -100,7 +92,6 @@ Exports bindings from the current module.
 Make declarations that the compiler finds useful
 
 ### include
-
 ``` scheme
 (include path)
 ```
@@ -108,7 +99,6 @@ Make declarations that the compiler finds useful
 Include the contents of path, wrapped with a `begin`.
 
 ### cond-expand
-
 ``` scheme
 (cond-expand
  (feature body ...) ...
@@ -124,7 +114,6 @@ Include the contents of path, wrapped with a `begin`.
 Conditionally expands the body for the first satisfied feature. Must appear at top scope.
 
 ### provide
-
 ``` scheme
 (provide id ...)
 ```
@@ -132,19 +121,16 @@ Conditionally expands the body for the first satisfied feature. Must appear at t
 Binds `id ...` as features provided by a module.
 
 ### define-values
-
 ``` scheme
 (define-values (id ...) expr)
 ```
 
 ### define-syntax
-
 ``` scheme
 (define-syntax id expr)
 ```
 
 ### define-alias
-
 ``` scheme
 (define-alias id alias-id)
 ```
@@ -152,7 +138,6 @@ Binds `id ...` as features provided by a module.
 Defines a syntactic alias for `id` to be the same as `alias-id`
 
 ### extern
-
 ``` scheme
 (extern id ...)
 (extern namespace: [namespace-id | #f] id ...)
@@ -162,9 +147,7 @@ Create runtime bindings for `id`, with the symbols bound at runtime through an
 external mechanism (eg builtin or defined at a foreign library).
 
 ## Expressions
-
 ### lambda%
-
 ``` scheme
 (lambda% lambda-formals body ...)
 ```
@@ -172,13 +155,11 @@ external mechanism (eg builtin or defined at a foreign library).
 Plain old Scheme `lambda`, without optional and keyword argument support
 
 ### case-lambda
-
 ``` scheme
 (case-lambda (lambda-formals body ...) ...)
 ```
 
 ### let-values letrec-values letrec\*-values
-
 ``` scheme
 (let-values (((id ...) expr) ...) body ...)
 (letrec-values (((id ...) expr) ...) body ...)
@@ -186,27 +167,23 @@ Plain old Scheme `lambda`, without optional and keyword argument support
 ```
 
 ### let-syntax letrec-syntax
-
 ``` scheme
 (let-syntax ((id syntax-expr) ...) body ...)
 (letrec-syntax ((id syntax-expr) ...) body ...)
 ```
 
 ### if
-
 ``` scheme
 (if test-expr then-expr else-expr)
 (if test-expr then-expr)
 ```
 
 ### quote
-
 ``` scheme
 (quote datum)
 ```
 
 ### quote-syntax
-
 ``` scheme
 (quote-syntax id)
 ```
@@ -214,7 +191,6 @@ Plain old Scheme `lambda`, without optional and keyword argument support
 Quote an identifier `id`, capturing its syntactic context.
 
 ## Expander Hooks
-
 ```
 (%%app rator rand ...)
 (%%ref id)
@@ -224,9 +200,8 @@ Quote an identifier `id`, capturing its syntactic context.
 Special expander indirection hooks; explained elsewhere in the documentation.
 
 ## Reserved Syntactic Tokens
-
 The following widely used syntactic tokens are defined as reserved expanders:
-
 ```
 _ ... else => unquote unquote-splicing unsyntax unsyntax-splicing
 ```
+

--- a/doc/reference/std/generic.md
+++ b/doc/reference/std/generic.md
@@ -43,371 +43,371 @@ Please document me!
 
 ## Predefined Types
 
-### <bignum>
+### \<bignum>
 ```
 (defprimitive-type <bignum> ...)
 ```
 
 Please document me!
 
-### <boolean>
+### \<boolean>
 ```
 (defprimitive-type <boolean> ...)
 ```
 
 Please document me!
 
-### <box>
+### \<box>
 ```
 (defprimitive-type <box> ...)
 ```
 
 Please document me!
 
-### <byte-port>
+### \<byte-port>
 ```
 (defbuiltin-type <byte-port> ...)
 ```
 
 Please document me!
 
-### <char>
+### \<char>
 ```
 (defprimitive-type <char> ...)
 ```
 
 Please document me!
 
-### <character-port>
+### \<character-port>
 ```
 (defbuiltin-type <character-port> ...)
 ```
 
 Please document me!
 
-### <complex>
+### \<complex>
 ```
 (defprimitive-type <complex> ...)
 ```
 
 Please document me!
 
-### <condvar>
+### \<condvar>
 ```
 (defbuiltin-type <condvar> ...)
 ```
 
 Please document me!
 
-### <continuation>
+### \<continuation>
 ```
 (defprimitive-type <continuation> ...)
 ```
 
 Please document me!
 
-### <device-port>
+### \<device-port>
 ```
 (defbuiltin-type <device-port> ...)
 ```
 
 Please document me!
 
-### <directory-port>
+### \<directory-port>
 ```
 (defbuiltin-type <directory-port> ...)
 ```
 
 Please document me!
 
-### <eof>
+### \<eof>
 ```
 (defprimitive-type <eof> ...)
 ```
 
 Please document me!
 
-### <event-queue-port>
+### \<event-queue-port>
 ```
 (defbuiltin-type <event-queue-port> ...)
 ```
 
 Please document me!
 
-### <exception>
+### \<exception>
 ```
 (defbuiltin-type <exception> ...)
 ```
 
 Please document me!
 
-### <f32vector>
+### \<f32vector>
 ```
 (defprimitive-type <f32vector> ...)
 ```
 
 Please document me!
 
-### <f64vector>
+### \<f64vector>
 ```
 (defprimitive-type <f64vector> ...)
 ```
 
 Please document me!
 
-### <fixnum>
+### \<fixnum>
 ```
 (defprimitive-type <fixnum> ...)
 ```
 
 Please document me!
 
-### <flonum>
+### \<flonum>
 ```
 (defprimitive-type <flonum> ...)
 ```
 
 Please document me!
 
-### <foreign>
+### \<foreign>
 ```
 (defprimitive-type <foreign> ...)
 ```
 
 Please document me!
 
-### <hash-table>
+### \<hash-table>
 ```
 (defprimitive-type <hash-table> ...)
 ```
 
 Please document me!
 
-### <integer>
+### \<integer>
 ```
 (defprimitive-type <integer> ...)
 ```
 
 Please document me!
 
-### <keyword>
+### \<keyword>
 ```
 (defprimitive-type <keyword> ...)
 ```
 
 Please document me!
 
-### <mutex>
+### \<mutex>
 ```
 (defbuiltin-type <mutex> ...)
 ```
 
 Please document me!
 
-### <null>
+### \<null>
 ```
 (defprimitive-type <null> ...)
 ```
 
 Please document me!
 
-### <number>
+### \<number>
 ```
 (defprimitive-type <number> ...)
 ```
 
 Please document me!
 
-### <object-port>
+### \<object-port>
 ```
 (defbuiltin-type <object-port> ...)
 ```
 
 Please document me!
 
-### <object>
+### \<object>
 ```
 (defprimitive-type <object> ...)
 ```
 
 Please document me!
 
-### <pair>
+### \<pair>
 ```
 (defprimitive-type <pair> ...)
 ```
 
 Please document me!
 
-### <port>
+### \<port>
 ```
 (defbuiltin-type <port> ...)
 ```
 
 Please document me!
 
-### <procedure>
+### \<procedure>
 ```
 (defprimitive-type <procedure> ...)
 ```
 
 Please document me!
 
-### <promise>
+### \<promise>
 ```
 (defprimitive-type <promise> ...)
 ```
 
 Please document me!
 
-### <rational>
+### \<rational>
 ```
 (defprimitive-type <rational> ...)
 ```
 
 Please document me!
 
-### <raw-device-port>
+### \<raw-device-port>
 ```
 (defbuiltin-type <raw-device-port> ...)
 ```
 
 Please document me!
 
-### <readtable>
+### \<readtable>
 ```
 (defbuiltin-type <readtable> ...)
 ```
 
 Please document me!
 
-### <real>
+### \<real>
 ```
 (defprimitive-type <real> ...)
 ```
 
 Please document me!
 
-### <s16vector>
+### \<s16vector>
 ```
 (defprimitive-type <s16vector> ...)
 ```
 
 Please document me!
 
-### <s32vector>
+### \<s32vector>
 ```
 (defprimitive-type <s32vector> ...)
 ```
 
 Please document me!
 
-### <s64vector>
+### \<s64vector>
 ```
 (defprimitive-type <s64vector> ...)
 ```
 
 Please document me!
 
-### <s8vector>
+### \<s8vector>
 ```
 (defprimitive-type <s8vector> ...)
 ```
 
 Please document me!
 
-### <string-port>
+### \<string-port>
 ```
 (defbuiltin-type <string-port> ...)
 ```
 
 Please document me!
 
-### <string>
+### \<string>
 ```
 (defprimitive-type <string> ...)
 ```
 
 Please document me!
 
-### <symbol>
+### \<symbol>
 ```
 (defprimitive-type <symbol> ...)
 ```
 
 Please document me!
 
-### <t>
+### \<t>
 ```
 (defprimitive-type <t> ...)
 ```
 
 Please document me!
 
-### <tcp-server-port>
+### \<tcp-server-port>
 ```
 (defbuiltin-type <tcp-server-port> ...)
 ```
 
 Please document me!
 
-### <thread-group>
+### \<thread-group>
 ```
 (defbuiltin-type <thread-group> ...)
 ```
 
 Please document me!
 
-### <thread>
+### \<thread>
 ```
 (defbuiltin-type <thread> ...)
 ```
 
 Please document me!
 
-### <time>
+### \<time>
 ```
 (defbuiltin-type <time> ...)
 ```
 
 Please document me!
 
-### <type>
+### \<type>
 ```
 (defbuiltin-type <type> ...)
 ```
 
 Please document me!
 
-### <u16vector>
+### \<u16vector>
 ```
 (defprimitive-type <u16vector> ...)
 ```
 
 Please document me!
 
-### <u32vector>
+### \<u32vector>
 ```
 (defprimitive-type <u32vector> ...)
 ```
 
 Please document me!
 
-### <u64vector>
+### \<u64vector>
 ```
 (defprimitive-type <u64vector> ...)
 ```
 
 Please document me!
 
-### <u8vector-port>
+### \<u8vector-port>
 ```
 (defbuiltin-type <u8vector-port> ...)
 ```
 
 Please document me!
 
-### <u8vector>
+### \<u8vector>
 
 ```
 (defprimitive-type <u8vector> ...)
@@ -415,28 +415,28 @@ Please document me!
 
 Please document me!
 
-### <values>
+### \<values>
 ```
 (defprimitive-type <values> ...)
 ```
 
 Please document me!
 
-### <vector-port>
+### \<vector-port>
 ```
 (defbuiltin-type <vector-port> ...)
 ```
 
 Please document me!
 
-### <vector>
+### \<vector>
 ```
 (defprimitive-type <vector> ...)
 ```
 
 Please document me!
 
-### <void>
+### \<void>
 ```
 (defbuiltin-type <void> ...)
 ```

--- a/doc/reference/std/iterators.md
+++ b/doc/reference/std/iterators.md
@@ -1,6 +1,6 @@
 # Iterators
 
-The `:std/iter` library provides iterator support; see the [Guide](/guide/intro.html#iteration)
+The `:std/iter` library provides iterator support; see the [Guide](/guide/intro.md#iteration)
 for an introduction.
 
 ::: tip To use bindings from this module:

--- a/doc/reference/std/iterators.md
+++ b/doc/reference/std/iterators.md
@@ -1,6 +1,6 @@
 # Iterators
 
-The `:std/iter` library provides iterator support; see the [Guide](../guide/intro.md#iteration)
+The `:std/iter` library provides iterator support; see the [Guide](/guide/intro.html#iteration)
 for an introduction.
 
 ::: tip To use bindings from this module:
@@ -10,6 +10,7 @@ for an introduction.
 ## Macros
 
 ### for
+
 ```scheme
 (for <bind> body ...)
 (for (<bind> ...) body ...)
@@ -30,7 +31,8 @@ produced to the binding pattern, and evaluates the body for each value.
 For each iterable object an iterator is constructed using `(iter ...)`;
 the iteration completes as soon as one of the iterators completes.
 
-### for*
+### for\*
+
 ```scheme
 (for* (<bind> ...) body ...)
 (for* (<bind> when <filter-expr> ...) body ...)
@@ -40,6 +42,7 @@ the iteration completes as soon as one of the iterators completes.
 `for*` iterates one or more iterables sequentially.
 
 ### for/collect
+
 ```scheme
 (for/collect <bind> body ...)
 (for/collect (<bind> ...) body ...)
@@ -51,6 +54,7 @@ the iteration completes as soon as one of the iterators completes.
 for each iteration into a list.
 
 ### for/fold
+
 ```scheme
 (for/fold <iv-bind> <bind> body ...)
 (for/fold <iv-bind> (<bind> ...) body ...)
@@ -68,6 +72,7 @@ result of the final iteration.
 ## Iterator Constructors
 
 ### iter
+
 ```scheme
 (iter obj) -> iterator
 ```
@@ -76,8 +81,8 @@ This is the fundamental iterator constructor for iterable objects.
 If the object is already an iterator then it is returned; otherwise
 the generic `:iter` is applied.
 
-
 ### :iter
+
 ```scheme
 (:iter obj) -> iterator
 
@@ -92,6 +97,7 @@ procedures which are iterated as coroutines; objects without any
 method binding dispatch to the `:iter` object method.
 
 ### in-iota
+
 ```scheme
 (in-iota count [start = 0] [step = 1]) -> iterator
 
@@ -103,6 +109,7 @@ Creates an iterator that yields `count` values starting from `start`
 and incrementing by `step`.
 
 ### in-range
+
 ```scheme
 (in-range end) -> iterator
 
@@ -127,6 +134,7 @@ Before v0.15, it was like `in-iota` except that `start` came before `count`
 when 2 or 3 parameters were used.
 
 ### in-naturals
+
 ```scheme
 (in-naturals [start = 0] [step = 1]) -> iterator
 
@@ -145,6 +153,7 @@ and doesn't accept an optional step, always using 1,
 whereas Gerbil accepts any number for start and step.
 
 ### in-hash
+
 ```scheme
 (in-hash ht) -> iterator
 
@@ -155,6 +164,7 @@ Creates an iterator that yields the key/value pairs (as two values) for each ass
 in the hash table. This is the same as `(:iter <hash-table>)`.
 
 ### in-hash-keys
+
 ```scheme
 (in-hash-keys ht) -> iterator
 
@@ -164,6 +174,7 @@ in the hash table. This is the same as `(:iter <hash-table>)`.
 Creates an iterator that yields the keys for each association in the hash table.
 
 ### in-hash-values
+
 ```scheme
 (in-hash-values ht) -> iterator
 ```
@@ -171,6 +182,7 @@ Creates an iterator that yields the keys for each association in the hash table.
 Creates an iterator that yields the values for each association in the hash table.
 
 ### in-input-port
+
 ```
 (in-input-port port [read]) -> iterator
 
@@ -181,6 +193,7 @@ Creates an iterator that yields the values read with `read` from the `port`.
 The unary version is the same as `(:iter port)`.
 
 ### in-input-lines
+
 ```
 (in-input-lines port) -> iterator
 
@@ -190,6 +203,7 @@ The unary version is the same as `(:iter port)`.
 Same as `(in-input-port port read-line)`.
 
 ### in-input-chars
+
 ```scheme
 (in-input-chars port) -> iterator
 
@@ -199,6 +213,7 @@ Same as `(in-input-port port read-line)`.
 Same as `(in-input-port port read-char)`.
 
 ### in-input-bytes
+
 ```scheme
 (in-input-bytes port) -> iterator
 
@@ -208,6 +223,7 @@ Same as `(in-input-port port read-char)`.
 Same as `(in-input-port port read-u8)`.
 
 ### in-coroutine
+
 ```scheme
 (in-coroutine proc arg ...) -> iterator
 
@@ -218,6 +234,7 @@ Creates an iterator that applies `(proc arg ...)` in a coroutine.
 The unary version is the same as `(:iter <procedure>)`.
 
 ### in-cothread
+
 ```scheme
 (in-cothread proc arg ...) -> iterator
 
@@ -226,10 +243,10 @@ The unary version is the same as `(:iter <procedure>)`.
 
 Creates an iterator that applies `(proc arg ...)` in a cothread.
 
-
 ## Iterator Protocol
 
 ### iterator
+
 ```scheme
 (defstruct iterator (e next fini))
 
@@ -239,6 +256,7 @@ fini := lambda (iterator)
 ```
 
 This is the type of iterator objects:
+
 - The element `e` is the state associated with the iterator
 - The procedure `next` advances the iterator and returns the current value; `iter-end` signals the end of the iteration.
 - The procedure `fini` finalizes the iterator. It is invoked at the end of the iteration by the `for` family of macros.
@@ -248,6 +266,7 @@ If the iterator has hard state associated (e.g. a thread or some other expensive
 will should be attached to it.
 
 ### iter-end
+
 ```scheme
 (def iter-end ...)
 ```
@@ -255,6 +274,7 @@ will should be attached to it.
 Special object signalling the end of iteration.
 
 ### iter-end?
+
 ```scheme
 (iter-end? obj) -> boolean
 ```
@@ -262,6 +282,7 @@ Special object signalling the end of iteration.
 Returns true if the object is the end of iteration object.
 
 ### iter-next!
+
 ```scheme
 (iter-next! it) -> any
 
@@ -271,6 +292,7 @@ Returns true if the object is the end of iteration object.
 Advances the iterator and returns the current value.
 
 ### iter-fini!
+
 ```scheme
 (iter-fini! it) -> unspecified
 
@@ -280,25 +302,26 @@ Advances the iterator and returns the current value.
 Finalizes the iterator.
 
 ### yield
-``` scheme
+
+```scheme
 (yield val ...) -> unspecified
 ```
 
 Yields one or more values from a coroutine procedure associated with an iterator.
 This is the `yield` defined in `:std/coroutine`.
 
-
 ## Examples
 
 Here is the definition for an iterator that produces a constant value,
 using the iterator protocol:
+
 ```scheme
 (def (iter-const val)
   (make-iterator val iterator-e))
 ```
 
-
 Here is a definition of the list iterator using the iterator protocol:
+
 ```scheme
 (def (iter-list lst)
   (def (next it)
@@ -312,6 +335,7 @@ Here is a definition of the list iterator using the iterator protocol:
 ```
 
 Here is a definition of the list iterator using coroutines:
+
 ```scheme
 (def (iter-list lst)
   (def (iterate lst)

--- a/doc/reference/std/iterators.md
+++ b/doc/reference/std/iterators.md
@@ -1,4 +1,5 @@
 # Iterators
+
 The `:std/iter` library provides iterator support; see the [Guide](/guide/intro.html#iteration)
 for an introduction.
 
@@ -238,7 +239,6 @@ fini := lambda (iterator)
 ```
 
 This is the type of iterator objects:
-
 - The element `e` is the state associated with the iterator
 - The procedure `next` advances the iterator and returns the current value; `iter-end` signals the end of the iteration.
 - The procedure `fini` finalizes the iterator. It is invoked at the end of the iteration by the `for` family of macros.
@@ -297,6 +297,7 @@ using the iterator protocol:
   (make-iterator val iterator-e))
 ```
 
+
 Here is a definition of the list iterator using the iterator protocol:
 ```scheme
 (def (iter-list lst)
@@ -309,7 +310,6 @@ Here is a definition of the list iterator using the iterator protocol:
         (else iter-end))))
   (make-iterator lst next))
 ```
-
 
 Here is a definition of the list iterator using coroutines:
 ```scheme

--- a/doc/reference/std/iterators.md
+++ b/doc/reference/std/iterators.md
@@ -1,5 +1,4 @@
 # Iterators
-
 The `:std/iter` library provides iterator support; see the [Guide](/guide/intro.html#iteration)
 for an introduction.
 
@@ -10,7 +9,6 @@ for an introduction.
 ## Macros
 
 ### for
-
 ```scheme
 (for <bind> body ...)
 (for (<bind> ...) body ...)
@@ -32,7 +30,6 @@ For each iterable object an iterator is constructed using `(iter ...)`;
 the iteration completes as soon as one of the iterators completes.
 
 ### for\*
-
 ```scheme
 (for* (<bind> ...) body ...)
 (for* (<bind> when <filter-expr> ...) body ...)
@@ -42,7 +39,6 @@ the iteration completes as soon as one of the iterators completes.
 `for*` iterates one or more iterables sequentially.
 
 ### for/collect
-
 ```scheme
 (for/collect <bind> body ...)
 (for/collect (<bind> ...) body ...)
@@ -54,7 +50,6 @@ the iteration completes as soon as one of the iterators completes.
 for each iteration into a list.
 
 ### for/fold
-
 ```scheme
 (for/fold <iv-bind> <bind> body ...)
 (for/fold <iv-bind> (<bind> ...) body ...)
@@ -72,7 +67,6 @@ result of the final iteration.
 ## Iterator Constructors
 
 ### iter
-
 ```scheme
 (iter obj) -> iterator
 ```
@@ -81,8 +75,8 @@ This is the fundamental iterator constructor for iterable objects.
 If the object is already an iterator then it is returned; otherwise
 the generic `:iter` is applied.
 
-### :iter
 
+### :iter
 ```scheme
 (:iter obj) -> iterator
 
@@ -97,7 +91,6 @@ procedures which are iterated as coroutines; objects without any
 method binding dispatch to the `:iter` object method.
 
 ### in-iota
-
 ```scheme
 (in-iota count [start = 0] [step = 1]) -> iterator
 
@@ -109,7 +102,6 @@ Creates an iterator that yields `count` values starting from `start`
 and incrementing by `step`.
 
 ### in-range
-
 ```scheme
 (in-range end) -> iterator
 
@@ -134,7 +126,6 @@ Before v0.15, it was like `in-iota` except that `start` came before `count`
 when 2 or 3 parameters were used.
 
 ### in-naturals
-
 ```scheme
 (in-naturals [start = 0] [step = 1]) -> iterator
 
@@ -153,7 +144,6 @@ and doesn't accept an optional step, always using 1,
 whereas Gerbil accepts any number for start and step.
 
 ### in-hash
-
 ```scheme
 (in-hash ht) -> iterator
 
@@ -164,7 +154,6 @@ Creates an iterator that yields the key/value pairs (as two values) for each ass
 in the hash table. This is the same as `(:iter <hash-table>)`.
 
 ### in-hash-keys
-
 ```scheme
 (in-hash-keys ht) -> iterator
 
@@ -174,7 +163,6 @@ in the hash table. This is the same as `(:iter <hash-table>)`.
 Creates an iterator that yields the keys for each association in the hash table.
 
 ### in-hash-values
-
 ```scheme
 (in-hash-values ht) -> iterator
 ```
@@ -182,7 +170,6 @@ Creates an iterator that yields the keys for each association in the hash table.
 Creates an iterator that yields the values for each association in the hash table.
 
 ### in-input-port
-
 ```
 (in-input-port port [read]) -> iterator
 
@@ -193,7 +180,6 @@ Creates an iterator that yields the values read with `read` from the `port`.
 The unary version is the same as `(:iter port)`.
 
 ### in-input-lines
-
 ```
 (in-input-lines port) -> iterator
 
@@ -203,7 +189,6 @@ The unary version is the same as `(:iter port)`.
 Same as `(in-input-port port read-line)`.
 
 ### in-input-chars
-
 ```scheme
 (in-input-chars port) -> iterator
 
@@ -213,7 +198,6 @@ Same as `(in-input-port port read-line)`.
 Same as `(in-input-port port read-char)`.
 
 ### in-input-bytes
-
 ```scheme
 (in-input-bytes port) -> iterator
 
@@ -223,7 +207,6 @@ Same as `(in-input-port port read-char)`.
 Same as `(in-input-port port read-u8)`.
 
 ### in-coroutine
-
 ```scheme
 (in-coroutine proc arg ...) -> iterator
 
@@ -234,7 +217,6 @@ Creates an iterator that applies `(proc arg ...)` in a coroutine.
 The unary version is the same as `(:iter <procedure>)`.
 
 ### in-cothread
-
 ```scheme
 (in-cothread proc arg ...) -> iterator
 
@@ -243,10 +225,10 @@ The unary version is the same as `(:iter <procedure>)`.
 
 Creates an iterator that applies `(proc arg ...)` in a cothread.
 
+
 ## Iterator Protocol
 
 ### iterator
-
 ```scheme
 (defstruct iterator (e next fini))
 
@@ -266,7 +248,6 @@ If the iterator has hard state associated (e.g. a thread or some other expensive
 will should be attached to it.
 
 ### iter-end
-
 ```scheme
 (def iter-end ...)
 ```
@@ -274,7 +255,6 @@ will should be attached to it.
 Special object signalling the end of iteration.
 
 ### iter-end?
-
 ```scheme
 (iter-end? obj) -> boolean
 ```
@@ -282,7 +262,6 @@ Special object signalling the end of iteration.
 Returns true if the object is the end of iteration object.
 
 ### iter-next!
-
 ```scheme
 (iter-next! it) -> any
 
@@ -292,7 +271,6 @@ Returns true if the object is the end of iteration object.
 Advances the iterator and returns the current value.
 
 ### iter-fini!
-
 ```scheme
 (iter-fini! it) -> unspecified
 
@@ -302,26 +280,24 @@ Advances the iterator and returns the current value.
 Finalizes the iterator.
 
 ### yield
-
-```scheme
+``` scheme
 (yield val ...) -> unspecified
 ```
 
 Yields one or more values from a coroutine procedure associated with an iterator.
 This is the `yield` defined in `:std/coroutine`.
 
+
 ## Examples
 
 Here is the definition for an iterator that produces a constant value,
 using the iterator protocol:
-
 ```scheme
 (def (iter-const val)
   (make-iterator val iterator-e))
 ```
 
 Here is a definition of the list iterator using the iterator protocol:
-
 ```scheme
 (def (iter-list lst)
   (def (next it)
@@ -334,8 +310,8 @@ Here is a definition of the list iterator using the iterator protocol:
   (make-iterator lst next))
 ```
 
-Here is a definition of the list iterator using coroutines:
 
+Here is a definition of the list iterator using coroutines:
 ```scheme
 (def (iter-list lst)
   (def (iterate lst)

--- a/doc/reference/std/make.md
+++ b/doc/reference/std/make.md
@@ -1,7 +1,7 @@
 # Build Tool
 
 The `:std/make` library provides support for building source Gerbil projects.
-See also the [guide](/reference/dev/build.md).
+See also the [Guide](/reference/dev/build.md).
 
 ::: tip usage
 (import :std/make)

--- a/doc/reference/std/stxparam.md
+++ b/doc/reference/std/stxparam.md
@@ -40,7 +40,7 @@ The `@@message` syntax parameter can also be cleanly re-parameterized without
 affecting existing macros.
 
 See [Keeping it Clean with Syntax Parameters](http://eli.barzilay.org/misc/stxparam.pdf)
-and [std/actor/message.ss](https://github.com/mighty-gerbils/gerbil/blob/master/src/std/actor/message.ss).
+and [std/actor-v18/message.ss](https://github.com/mighty-gerbils/gerbil/blob/master/src/std/actor-v18/message.ss).
 
 :::
 


### PR DESCRIPTION
- Reference - Prelude - Core Expander Syntax: the opening paragraph now links to the reference of the `current-expander-context` instead of 404ing.
	- fixed comment spacing in the `core-expand` example.

- Reference - Standard Library - Generics: all the predefined types starting with `<` failed to render on the site, this has been corrected and they should now render correctly, including the sidebar content of said types.


- Reference - Standard Library - Iterators: now correctly links to the Guide explaining iterators.

- refer to "the guide" on in on the website itself as "Guide" with uppercase G. This seemed to be a pattern in other parts of the docs.

- Reference - Standard Library - Syntax Parameters: link to the `std/actor-v18/message.ss` instead of `actor`. `actor` does not exist, only `actor-v18` and `actor-v13`. Is `v18` the correct one to link to?