### PR TITLE
fix bug in protobuf expansion

### DIFF
--- a/src/std/protobuf/macros.ss
+++ b/src/std/protobuf/macros.ss
@@ -51,7 +51,7 @@
                   ((cases ...)
                    (map (lambda (key val)
                           (with-syntax ((key key) (val val))
-                            #'((key) (&BufferedWriter-write-varint* val buf))))
+                            #'((key) (&BufferedWriter-write-varint* buf val))))
                         keys vals)))
       #'(defwriter-ext* (bio-write buf val)
           (case val

--- a/src/std/protobuf/protobuf-test.ss
+++ b/src/std/protobuf/protobuf-test.ss
@@ -86,6 +86,22 @@
                                BufferedReader-read-Test7 BufferedWriter-write-Test7)
       )
 
+    (test-case "test enum"
+      (defenum E
+        (a 1)
+        (b 2)
+        (c 3))
+
+      (defmessage A
+        optional: (a 1 E))
+
+      (check-marshal-unmarshal (A a: 'a)
+                               BufferedReader-read-A BufferedWriter-write-A)
+      (check-marshal-unmarshal (A a: 'b)
+                               BufferedReader-read-A BufferedWriter-write-A)
+      (check-marshal-unmarshal (A a: 'c)
+                               BufferedReader-read-A BufferedWriter-write-A))
+
     (test-case "test oneof"
       (defmessage A
         oneof: (a (s 1 string) (i 2 int32)))


### PR DESCRIPTION
unchecked call to write-varint* ... with arguments in the wrong order. :facepalm: