### PR TITLE
Add syntax for string keys in let-hash.

### DIFF
--- a/doc/reference/std/sugar.md
+++ b/doc/reference/std/sugar.md
@@ -294,16 +294,17 @@ resolve as hash references.
 
 More specifically, the macro rebinds `%%ref` so that identifiers starting with a `.`
 are resolved with the following rules:
-- `.x  -> (hash-ref hash 'x)` ; strong accessor
-- `.?x -> (hash-get hash 'x)` ; weak accessor
-- `..x -> (%%ref .x)`         ; escape
+- `.x  -> (hash-ref hash 'x)`  ; strong accessor
+- `.?x -> (hash-get hash 'x)`  ; weak accessor
+- `.$x -> (hash-get hash "x")` ; string weak accessor
+- `..x -> (%%ref .x)`          ; escape
 
 ::: tip Examples:
 ```scheme
 > (def .c 4)
-> (def h (hash (a 1) (b 2) (c 3)))
-> (let-hash h [.a .?b ..c .?d])
-(1 2 4 #f)
+> (def h (hash (a 1) (b 2) (c 3) ("d" 5)))
+> (let-hash h [.a .?b ..c .$d .?e])
+(1 2 4 5 #f)
 ```
 :::
 

--- a/src/std/sugar-test.ss
+++ b/src/std/sugar-test.ss
@@ -113,8 +113,8 @@
 
     (test-case "let-hash"
       (def .c 4)
-      (def h (hash (a 1) (b 2) (c 3)))
-      (check (let-hash h [.a .?b ..c .?d]) => [1 2 4 #f]))
+      (def h (hash (a 1) (b 2) (c 3) ("d" 5)))
+      (check (let-hash h [.a .?b ..c .$d .?e]) => [1 2 4 5 #f]))
 
     (test-case "awhen"
       (def (foo c) (awhen (v (char-ascii-digit c)) (* v v)))


### PR DESCRIPTION
Some tables contain string keys. Having let-hash properly handle string keys is thus important. The '.$id' syntax is short and in line with the other prefixes in let-hash. Weak accessor only.