### PR TITLE
consistently take local package context into account in gerbil tools

### DIFF
--- a/src/std/interface.ss
+++ b/src/std/interface.ss
@@ -568,7 +568,7 @@
                            instance-satisfies-predicate: (quote-syntax instance-predicate)
                            implementation-methods: [(quote-syntax method-impl-name) ...]
                            unchecked-implementation-methods: [(quote-syntax unchecked-method-impl-name) ...]))))
-       #'(begin defklass defdescriptor defmake defpred defpred-instance definfo
+       #'(begin defklass defdescriptor defmake deftry-make defpred defpred-instance definfo
                 defmethod-impl ...)))))
 
 (defsyntax-for-export (interface-out stx)

--- a/src/tools/build.ss
+++ b/src/tools/build.ss
@@ -3,7 +3,8 @@
 (import :std/build-script)
 
 (defbuild-script
-  '("gxprof"
+  '("env"
+    "gxprof"
     "gxtags"
     "gxpkg"
     "gxtest"

--- a/src/tools/env.ss
+++ b/src/tools/env.ss
@@ -1,0 +1,14 @@
+;;; -*- Gerbil -*-
+;;; © vyzo
+;;; common environment context for tools
+(import (only-in :gerbil/runtime/init cons-load-path))
+(export #t)
+
+(def (setup-local-env!)
+  (unless (getenv "GERBIL_PATH" #f)
+    (let* ((here (path-normalize (current-directory)))
+           (gerbil.pkg (path-expand "gerbil.pkg" here))
+           (gerbil-path (path-expand ".gerbil" here)))
+      (when (and (file-exists? gerbil.pkg) (file-exists? gerbil-path))
+        (setenv "GERBIL_PATH" gerbil-path)
+        (cons-load-path (path-expand "lib" gerbil-path))))))

--- a/src/tools/gxensemble.ss
+++ b/src/tools/gxensemble.ss
@@ -16,7 +16,8 @@
         :std/misc/process
         :std/os/hostname
         :std/sugar
-        :std/text/hex)
+        :std/text/hex
+        ./env)
 (export main)
 
 (def (main . args)
@@ -414,6 +415,7 @@
         gopts ...))))
 
 (def (gxensemble-main cmd opt)
+  (setup-local-env!)
   (dispatch-command cmd opt main-commands))
 
 (defcommand-nested do-admin admin-commands "gxensemble admin"

--- a/src/tools/gxprof.ss
+++ b/src/tools/gxprof.ss
@@ -11,7 +11,8 @@
         :std/cli/getopt
         :std/format
         :std/sort
-        :std/sugar)
+        :std/sugar
+        ./env)
 (export main)
 
 (def (main . args)
@@ -33,6 +34,7 @@
       help: "arguments to pass to the executable module's main")))
 
 (def (gxprof-main opt)
+  (setup-local-env!)
   (let-hash opt
     (if .?module
       (let* ((ctx (import-module (module-path .module) #f #t))

--- a/src/tools/gxtags.ss
+++ b/src/tools/gxtags.ss
@@ -14,7 +14,8 @@
         :std/sort
         (only-in :std/srfi/1 delete-duplicates reverse!)
         :std/sugar
-        :std/text/utf8)
+        :std/text/utf8
+        ./env)
 (export main make-tags)
 
 (def (main . args)
@@ -33,6 +34,7 @@
       help: "source file or directory")))
 
 (def (gxtags-main opt)
+  (setup-local-env!)
   (run (hash-ref opt 'input ["."])
        (hash-get opt 'output)
        (hash-get opt 'append)

--- a/src/tools/gxtest.ss
+++ b/src/tools/gxtest.ss
@@ -10,7 +10,8 @@
         :std/sort
         :std/srfi/13
         :std/sugar
-        :std/test)
+        :std/test
+        (only-in :gerbil/runtime/init cons-load-path))
 (export main)
 
 (def (main . args)
@@ -33,7 +34,8 @@
     (let* ((here (path-normalize (current-directory)))
            (gerbil-path (path-expand ".gerbil" here)))
       (when (file-exists? gerbil-path)
-        (setenv "GERBIL_PATH" gerbil-path))))
+        (setenv "GERBIL_PATH" gerbil-path)
+        (cons-load-path (path-expand "lib" gerbil-path)))))
 
   (let-hash opt
     (cond

--- a/src/tools/gxtest.ss
+++ b/src/tools/gxtest.ss
@@ -30,7 +30,7 @@
 (def (gxtest-main opt)
   ;; local package context
   (unless (getenv "GERBIL_PATH" #f)
-    (let* ((here (path-normalize* (current-directory)))
+    (let* ((here (path-normalize (current-directory)))
            (gerbil-path (path-expand ".gerbil" here)))
       (when (file-exists? gerbil-path)
         (setenv "GERBIL_PATH" gerbil-path))))

--- a/src/tools/gxtest.ss
+++ b/src/tools/gxtest.ss
@@ -11,7 +11,7 @@
         :std/srfi/13
         :std/sugar
         :std/test
-        (only-in :gerbil/runtime/init cons-load-path))
+        ./env)
 (export main)
 
 (def (main . args)
@@ -29,14 +29,7 @@
                      help: "test files or directories to execute tests in; appending /... to a directory will recursively execute or tests in it. If no arguments are passed, all tests in the current directory are executed.")))
 
 (def (gxtest-main opt)
-  ;; local package context
-  (unless (getenv "GERBIL_PATH" #f)
-    (let* ((here (path-normalize (current-directory)))
-           (gerbil-path (path-expand ".gerbil" here)))
-      (when (file-exists? gerbil-path)
-        (setenv "GERBIL_PATH" gerbil-path)
-        (cons-load-path (path-expand "lib" gerbil-path)))))
-
+  (setup-local-env!)
   (let-hash opt
     (cond
      ((null? .args)

--- a/src/tools/gxtest.ss
+++ b/src/tools/gxtest.ss
@@ -28,6 +28,13 @@
                      help: "test files or directories to execute tests in; appending /... to a directory will recursively execute or tests in it. If no arguments are passed, all tests in the current directory are executed.")))
 
 (def (gxtest-main opt)
+  ;; local package context
+  (unless (getenv "GERBIL_PATH" #f)
+    (let* ((here (path-normalize* (current-directory)))
+           (gerbil-path (path-expand ".gerbil" here)))
+      (when (file-exists? gerbil-path)
+        (setenv "GERBIL_PATH" gerbil-path))))
+
   (let-hash opt
     (cond
      ((null? .args)


### PR DESCRIPTION
So that we dont have to `gerbil env gerbil test` and :facepalm: 

Also, #1131 didn't quite fix the bug :scream_cat: 