### PR TITLE
Bio methods to read/write integers in decimal

### DIFF
--- a/src/std/io/bio/bio-test.ss
+++ b/src/std/io/bio/bio-test.ss
@@ -247,7 +247,22 @@
           (check (get-buffer-output-u8vector bwr) => output1))
         (let (bwr (open-buffered-writer #f))
           (check (BufferedWriter-write-line bwr input '(#\return #\newline)) => (fx+ (string-length input) 2))
-          (check (get-buffer-output-u8vector bwr) => output2))))))
+          (check (get-buffer-output-u8vector bwr) => output2))))
+
+    (test-case "digit output"
+      (def (write->string int)
+        (let (bwr (open-buffered-writer #f))
+          (BufferedWriter-write-digits bwr int)
+          (utf8->string (get-buffer-output-u8vector bwr))))
+
+      (check (write->string 6) => "6")
+      (check (write->string 666) => "666")
+      (check (write->string 1337) => "1337")
+      (check (write->string 123456789012345678901234567890123456789) => "123456789012345678901234567890123456789")
+      (check (write->string -6) => "-6")
+      (check (write->string -666) => "-666")
+      (check (write->string -1337) => "-1337")
+      (check (write->string -123456789012345678901234567890123456789) => "-123456789012345678901234567890123456789"))))
 
 (def bio-varint-delimited-test
   (test-suite "varint delimited i/o"

--- a/src/std/io/bio/bio-test.ss
+++ b/src/std/io/bio/bio-test.ss
@@ -157,7 +157,23 @@
         (let (brd (open-string-buffered-reader input3))
           (check (BufferedReader-read-line brd '(#\return #\newline)) => input1))
         (let (brd (open-string-buffered-reader input3))
-          (check (BufferedReader-read-line brd '(#\return #\newline) #t) => input3))))))
+          (check (BufferedReader-read-line brd '(#\return #\newline) #t) => input3))))
+
+    (test-case "digit input"
+      (def (read->int str)
+        (let (brd (open-buffered-reader (string->utf8 str)))
+          (BufferedReader-read-digits brd)))
+
+      (check (read->int "0") => 0)
+      (check (read->int "6") => 6)
+      (check (read->int "10") => 10)
+      (check (read->int "666") => 666)
+      (check (read->int "1337") => 1337)
+      (check (read->int "123456789012345678901234567890123456789") => 123456789012345678901234567890123456789)
+      (check (read->int "-6") => -6)
+      (check (read->int "-666") => -666)
+      (check (read->int "-1337") => -1337)
+      (check (read->int "-123456789012345678901234567890123456789") => -123456789012345678901234567890123456789))))
 
 (def bio-output-test
   (test-suite "buffered writer"
@@ -255,7 +271,9 @@
           (BufferedWriter-write-digits bwr int)
           (utf8->string (get-buffer-output-u8vector bwr))))
 
+      (check (write->string 0) => "0")
       (check (write->string 6) => "6")
+      (check (write->string 10) => "10")
       (check (write->string 666) => "666")
       (check (write->string 1337) => "1337")
       (check (write->string 123456789012345678901234567890123456789) => "123456789012345678901234567890123456789")

--- a/src/std/io/bio/util.ss
+++ b/src/std/io/bio/util.ss
@@ -538,6 +538,27 @@
     (reader.read buffer start (+ start count) 0)
     count))
 
+(defreader-ext (read-digits reader)
+  (let* ((maybe-sign? (reader.peek-u8))
+         (sign (if (eq? maybe-sign? 45)
+                 (begin
+                   (reader.read-u8)
+                   -1)
+                 1)))
+    (let lp ((result 0) (fx? #t))
+      (let (next (reader.peek-u8))
+        (cond
+         ((and (not (eof-object? next)) (fx<= 48 next 57))
+          (let* ((next (reader.read-u8))
+                 (digit (fx- next 48)))
+            (cond
+             ((and fx? (alet (result (##fx*? result 10)) (##fx+? digit result)))
+              => (cut lp <> #t))
+             (else
+              (lp (+ digit (* result 10)) #f)))))
+         (fx? (fx* sign result))
+         (else (* sign result)))))))
+
 ;; writer
 (defwriter-ext (write-u16 writer uint)
   (write-uint writer uint 2))

--- a/src/std/io/bio/util.ss
+++ b/src/std/io/bio/util.ss
@@ -661,6 +661,29 @@
       (let (wrote (writer.write-char-inline separator))
         (fx+ result wrote)))))
 
+(defwriter-ext (write-digits writer int)
+  (cond
+   ((fixnum? int)
+    (let (wr (if (fx< int 0)
+               (writer.write-u8 45)
+               0))
+      (let recur ((int (fxabs int)) (wr wr))
+        (let (wr (if (fx>= int 10)
+                   (recur (fxquotient int 10) wr)
+                   wr))
+        (fx+ wr (writer.write-u8 (fx+ (fxremainder int 10) 48)))))))
+   ((##bignum? int)
+    (let (wr (if (< int 0)
+               (writer.write-u8 45)
+               0))
+    (let recur ((int (abs int)) (wr wr))
+      (let (wr (if (>= int 10)
+                 (recur (quotient int 10) wr)
+                 wr))
+        (fx+ wr (writer.write-u8 (fx+ (remainder int 10) 48)))))))
+   (else
+    (raise-bad-argument write-digits "integer" int))))
+
 ;; expt caches
 (def +expt-cache+
   (let (cache (make-vector 64 #f))

--- a/src/std/net/httpd/logger.ss
+++ b/src/std/net/httpd/logger.ss
@@ -70,7 +70,7 @@
         (using (req :- http-request)
           (let* ((wr 0)
                  ;; timestamp
-                 (wr (fx+ wr (writer.write-string (number->string (exact (floor ts))))))
+                 (wr (fx+ wr (writer.write-digits (exact (floor ts)))))
                  (wr (fx+ wr (writer.write-char #\space)))
                  ;; client IP
                  (wr (fx+ wr (let (ip (car req.client))


### PR DESCRIPTION
So that we don't have to `number->string` right and left; and of course the httpd logger uses it.