### PR TITLE
minor fixes (not quite bugs) for gambit integration

### DIFF
--- a/src/std/srfi/1.ss
+++ b/src/std/srfi/1.ss
@@ -21,17 +21,17 @@
   list-ref
   memq memv
   assq assv
-
-  ;; gerbil runtime
-  cons* make-list iota
-  last last-pair
-  (rename: foldl fold)
-  (rename: foldr fold-right)
-  filter filter-map find
   map
   for-each
   member
   assoc
+  fold
+  fold-right
+
+  ;; gerbil runtime
+  cons* make-list iota
+  last last-pair
+  filter filter-map find
 
   ;; olin's implementation
   xcons tree-copy list-tabulate list-copy
@@ -66,5 +66,6 @@
   lset-union! lset-intersection! lset-difference! lset-xor! lset-diff+intersection!)
 
 (declare (fixnum))
-
+;; use the gambit primitives to avoid conflict in the integration
+(extern namespace: #f fold fold-right)
 (include "srfi-1.scm")

--- a/src/std/srfi/1.ss
+++ b/src/std/srfi/1.ss
@@ -28,12 +28,10 @@
   (rename: foldl fold)
   (rename: foldr fold-right)
   filter filter-map find
-
-  ;; specialized dispatch implementation
-  (rename: srfi-1-map map)
-  (rename: srfi-1-for-each for-each)
-  (rename: srfi-1-member member)
-  (rename: srfi-1-assoc assoc)
+  map
+  for-each
+  member
+  assoc
 
   ;; olin's implementation
   xcons tree-copy list-tabulate list-copy
@@ -68,58 +66,5 @@
   lset-union! lset-intersection! lset-difference! lset-xor! lset-diff+intersection!)
 
 (declare (fixnum))
-
-(def* srfi-1-map
-  ((f lst) (map f lst))
-  ((f lst1 lst2) (map2 f lst1 lst2))
-  ((f lst1 lst2 . lsts)
-   (apply mapN f lst1 lst2 lsts)))
-
-(def (map2 f lst1 lst2)
-  (let recur ((rest1 lst1) (rest2 lst2))
-    (match* (rest1 rest2)
-      (([x1 . rest1] [x2 . rest2])
-       (cons (f x1 x2) (recur rest1 rest2)))
-      (else []))))
-
-(def (mapN f . lsts)
-  (let recur ((rest lsts))
-    (if (andmap pair? rest)
-      (cons (apply f (map car rest))
-            (recur (map cdr rest)))
-      [])))
-
-(def* srfi-1-for-each
-  ((f lst) (for-each f lst))
-  ((f lst1 lst2)
-   (for-each2 f lst1 lst2))
-  ((f lst1 lst2 . lsts)
-   (apply for-eachN f lst1 lst2 lsts)))
-
-(def (for-each2 f lst1 lst2)
-  (let lp ((rest1 lst1) (rest2 lst2))
-    (match* (rest1 rest2)
-      (([x1 . rest1] [x2 . rest2])
-       (f x1 x2)
-       (lp rest1 rest2))
-      (else (void)))))
-
-(def (for-eachN f . lsts)
-  (let lp ((rest lsts))
-    (when (andmap pair? rest)
-      (apply f (map car rest))
-      (lp (map cdr rest)))))
-
-(def* srfi-1-assoc
-  ((x lst)
-   (assoc x lst))
-  ((x lst eqf)
-   (find (lambda (p) (eqf (car p) x)) lst)))
-
-(def* srfi-1-member
-  ((x lst)
-   (member x lst))
-  ((x lst eqf)
-   (find-tail (cut eqf <> x) lst)))
 
 (include "srfi-1.scm")

--- a/src/std/srfi/43.ss
+++ b/src/std/srfi/43.ss
@@ -35,7 +35,7 @@
   ;; * Mutators
   vector-set!
   vector-swap!
-  (rename: %%vector-fill! vector-fill!)
+  vector-fill!
   vector-reverse!
   vector-copy!                    vector-reverse-copy!
   vector-reverse!

--- a/src/std/srfi/43.ss
+++ b/src/std/srfi/43.ss
@@ -41,8 +41,8 @@
   vector-reverse!
 
   ;; * Conversion
-  (rename: %%vector->list vector->list) reverse-vector->list
-  (rename: %%list->vector list->vector) reverse-list->vector
+  vector->list reverse-vector->list
+  list->vector reverse-list->vector
   )
 
 (include "srfi-43.scm")

--- a/src/std/srfi/srfi-1.scm
+++ b/src/std/srfi/srfi-1.scm
@@ -855,9 +855,6 @@
 	    (let ((head (car lis)))
 	      (kons head (recur (cdr lis))))))))
 
-(defalias fold foldl)
-(defalias fold-right foldr)
-
 (define (pair-fold-right f zero lis1 . lists)
   (check-arg procedure? f pair-fold-right)
   (if (pair? lists)

--- a/src/std/srfi/srfi-1.scm
+++ b/src/std/srfi/srfi-1.scm
@@ -1445,7 +1445,7 @@
 	(or (not (pair? rest))
 	    (let ((s2 (car rest))  (rest (cdr rest)))
 	      (and (or (eq? s2 s1)	; Fast path
-		       (%lset2<= (flip =) s1 s2)) ; Real test
+		       (%lset2<= = s1 s2)) ; Real test
 		   (lp s2 rest)))))))
 
 (define (lset= = . lists)
@@ -1456,8 +1456,8 @@
 	    (let ((s2   (car rest))
 		  (rest (cdr rest)))
 	      (and (or (eq? s1 s2)	; Fast path
-		       (and (%lset2<= (flip =) s1 s2) ; Real test
-                            (%lset2<= = s2 s1)))
+		       (and (%lset2<= = s1 s2) ; Real test
+                            (%lset2<= (flip =) s2 s1)))
 		   (lp s2 rest)))))))
 
 

--- a/src/std/srfi/srfi-1.scm
+++ b/src/std/srfi/srfi-1.scm
@@ -1434,9 +1434,7 @@
 ;;;   FILTER in this source code share longest common tails between args
 ;;;   and results to get structure sharing in the lset procedures.
 
-;; Note how we use Gambit's member for srfi-1-member, and it uses the = predicate with the
-;; opposite order of arguments than the reference SRFI-1 implementation.
-(define (%lset2<= = lis1 lis2) (every (lambda (x) (srfi-1-member x lis2 =)) lis1))
+(define (%lset2<= = lis1 lis2) (every (lambda (x) (member x lis2 =)) lis1))
 
 (define (flip proc) (lambda (x y) (proc y x)))
 
@@ -1465,7 +1463,7 @@
 
 (define (lset-adjoin = lis . elts)
   (check-arg procedure? = lset-adjoin)
-  (fold (lambda (elt ans) (if (srfi-1-member elt ans =) ans (cons elt ans)))
+  (fold (lambda (elt ans) (if (member elt ans =) ans (cons elt ans)))
 	lis elts))
 
 
@@ -1504,7 +1502,7 @@
     (cond ((any null-list? lists) '())		; Short cut
 	  ((null? lists)          lis1)		; Short cut
 	  (else (filter (lambda (x)
-			  (every (lambda (lis) (srfi-1-member x lis =)) lists))
+			  (every (lambda (lis) (member x lis =)) lists))
 			lis1)))))
 
 (define (lset-intersection! = lis1 . lists)
@@ -1513,7 +1511,7 @@
     (cond ((any null-list? lists) '())		; Short cut
 	  ((null? lists)          lis1)		; Short cut
 	  (else (filter! (lambda (x)
-			   (every (lambda (lis) (srfi-1-member x lis =)) lists))
+			   (every (lambda (lis) (member x lis =)) lists))
 			 lis1)))))
 
 
@@ -1523,7 +1521,7 @@
     (cond ((null? lists)     lis1)	; Short cut
 	  ((memq lis1 lists) '())	; Short cut
 	  (else (filter (lambda (x)
-			  (every (lambda (lis) (not (srfi-1-member x lis =)))
+			  (every (lambda (lis) (not (member x lis =)))
 				 lists))
 			lis1)))))
 
@@ -1533,7 +1531,7 @@
     (cond ((null? lists)     lis1)	; Short cut
 	  ((memq lis1 lists) '())	; Short cut
 	  (else (filter! (lambda (x)
-			   (every (lambda (lis) (not (srfi-1-member x lis =)))
+			   (every (lambda (lis) (not (member x lis =)))
 				  lists))
 			 lis1)))))
 
@@ -1554,7 +1552,7 @@
 	      (cond ((null? a-b)     (lset-difference = b a))
 		    ((null? a-int-b) (append b a))
 		    (else (fold (lambda (xb ans)
-				  (if (srfi-1-member xb a-int-b =) ans (cons xb ans)))
+				  (if (member xb a-int-b =) ans (cons xb ans)))
 				a-b
 				b)))))
 	  '() lists))
@@ -1576,7 +1574,7 @@
 	      (cond ((null? a-b)     (lset-difference! = b a))
 		    ((null? a-int-b) (append! b a))
 		    (else (pair-fold (lambda (b-pair ans)
-				       (if (srfi-1-member (car b-pair) a-int-b =) ans
+				       (if (member (car b-pair) a-int-b =) ans
 					   (begin (set-cdr! b-pair ans) b-pair)))
 				     a-b
 				     b)))))
@@ -1588,7 +1586,7 @@
   (cond ((every null-list? lists) (values lis1 '()))	; Short cut
 	((memq lis1 lists)        (values '() lis1))	; Short cut
 	(else (partition (lambda (elt)
-			   (not (any (lambda (lis) (srfi-1-member elt lis =))
+			   (not (any (lambda (lis) (member elt lis =))
 				     lists)))
 			 lis1))))
 
@@ -1597,6 +1595,6 @@
   (cond ((every null-list? lists) (values lis1 '()))	; Short cut
 	((memq lis1 lists)        (values '() lis1))	; Short cut
 	(else (partition! (lambda (elt)
-			    (not (any (lambda (lis) (srfi-1-member elt lis =))
+			    (not (any (lambda (lis) (member elt lis =))
 				      lists)))
 			  lis1))))

--- a/src/std/srfi/srfi-43.scm
+++ b/src/std/srfi/srfi-43.scm
@@ -1102,7 +1102,7 @@
 ;;;   is 0, and END, whose default is the length of VECTOR, with VALUE.
 ;;;
 ;;; This one can probably be made really fast natively.
-(define %%vector-fill! ;; Gerbil: renamed to vector-fill on export
+#;(define %%vector-fill! ;; Gerbil: renamed to vector-fill on export
   (let ((%vector-fill! vector-fill!))   ; Take the native one, under
                                         ;   the assumption that it's
                                         ;   faster, so we can use it if

--- a/src/std/srfi/srfi-43.scm
+++ b/src/std/srfi/srfi-43.scm
@@ -1212,7 +1212,7 @@
 ;;;   [R5RS+] Produce a list containing the elements in the locations
 ;;;   between START, whose default is 0, and END, whose default is the
 ;;;   length of VECTOR, from VECTOR.
-(define %%vector->list ;; Gerbil: renamed to vector->list on export
+#;(define %%vector->list ;; Gerbil: renamed to vector->list on export
   (let ((%vector->list vector->list))
     (lambda (vec . maybe-start+end)
       (if (null? maybe-start+end)       ; Oughta use CASE-LAMBDA.
@@ -1255,7 +1255,7 @@
 ;;; and causes - to fail as well.  Given a LENGTH* that computes the
 ;;; length of a list's cycle, this wouldn't diverge, and would work
 ;;; great for circular lists.
-(define %%list->vector ;; Gerbil: renamed to list->vector on export
+#;(define %%list->vector ;; Gerbil: renamed to list->vector on export
   (let ((%list->vector list->vector))
     (lambda (lst . maybe-start+end)
       ;; Checking the type of a proper list is expensive, so we do it


### PR DESCRIPTION
Updates and minor fixes for gambit integration.
- remove obsolete defs of procedures now provided as gambit builtins.
- fix srfi 43 exports 