### PR TITLE
explicitly set the gerbil runtime namespace

### DIFF
--- a/src/gerbil/runtime.ss
+++ b/src/gerbil/runtime.ss
@@ -4,6 +4,7 @@
 ;;; Recursion; See Recursion
 prelude: "prelude/core"
 package: gerbil
+namespace: #f
 
 (provide gerbil-runtime)
 


### PR DESCRIPTION
for the gambit integration.