### PR TITLE
Emacs: fix font in etc/gerbil-mode.el

### DIFF
--- a/etc/gerbil-mode.el
+++ b/etc/gerbil-mode.el
@@ -480,7 +480,7 @@
   (gerbil-fontlock-add
    '("\\_<\\(\\sw+\\)\\.\\(\\sw+\\)\\_>"
      (1 font-lock-variable-name-face)
-     (2 font-lock-reference-face)))
+     (2 font-lock-constant-face)))
   (gerbil-fontlock-add
    '("\\_<\\([?!&]+\\)"
      (1 font-lock-builtin-face)))


### PR DESCRIPTION
`font-lock-reference-face`  is replace by `font-lock-constant-face` ([here](https://lists.nongnu.org/archive/html/emacs-devel/2022-09/msg01027.html))