### PR TITLE
Remove obsolete import statement.

### DIFF
--- a/src/std/interactive.ss
+++ b/src/std/interactive.ss
@@ -2,7 +2,6 @@
 ;;; © vyzo
 ;;; interactive development utilities
 
-(import (only-in :gerbil/gambit pretty-print))
 (export #t (for-syntax #t))
 
 (module <util>


### PR DESCRIPTION
This now expands to an empty statement and breaks the module.