### PR TITLE
prelude for hand-written .ssi files

### DIFF
--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -7,6 +7,7 @@
     "metaclass"
     "hash-table"
     "interactive"
+    "ssi"
     "foreign"
     ;; tests for :std/foreign
     "foreign-test-support"

--- a/src/std/db/_sqlite.ssi
+++ b/src/std/db/_sqlite.ssi
@@ -1,10 +1,11 @@
 ;;; -*- Gerbil -*-
 ;;; (C) vyzo at hackzen.org
 ;;; SQLite FFI
+prelude: :std/ssi
 package: std/db
 
 (export #t)
-(extern
+(defruntime
   SQLITE_OPEN_READONLY
   SQLITE_OPEN_READWRITE
   SQLITE_OPEN_CREATE

--- a/src/std/os/_socket.ssi
+++ b/src/std/os/_socket.ssi
@@ -1,10 +1,11 @@
 ;;; -*- Gerbil -*-
 ;;; (C) vyzo at hackzen.org
 ;;; OS socket FFI interface
+prelude: :std/ssi
 package: std/os
 
 (export #t)
-(extern
+(defruntime
   _socket
   _bind
   _listen

--- a/src/std/ssi.ss
+++ b/src/std/ssi.ss
@@ -1,0 +1,18 @@
+;; -*- Gerbil -*-
+;;; © vyzo
+;;; prelude for hand-written .ssi's
+(export begin module import export defruntime defalias load-module quote)
+
+(defsyntax (defruntime stx)
+  (syntax-case stx ()
+    ((_ id ...)
+     (identifier-list? #'(id ...))
+     (let (ns (module-context-ns (current-expander-context)))
+       (with-syntax (((bind-id ...)
+                      (stx-map (lambda (id)
+                                 (syntax-local-introduce
+                                  (make-symbol ns "#" (stx-e id))))
+                               #'(id ...))))
+         #'(begin
+             (%#define-runtime id bind-id)
+             ...))))))

--- a/src/std/text/_zlib.ssi
+++ b/src/std/text/_zlib.ssi
@@ -1,10 +1,11 @@
 ;;; -*- Gerbil -*-
 ;;; (C) vyzo at hackzen.org
 ;;; zlib FFI
+prelude: :std/ssi
 package: std/text
 
 (export #t)
-(extern
+(defruntime
   Z_OK Z_STREAM_END Z_NEED_DICT
   Z_NO_COMPRESSION Z_BEST_SPEED Z_BEST_COMPRESSION Z_DEFAULT_COMPRESSION
   Z_FINISH Z_NO_FLUSH

--- a/src/std/text/base64.ssi
+++ b/src/std/text/base64.ssi
@@ -1,12 +1,12 @@
 ;;; -*- Gerbil -*-
 ;;; (C) vyzo at hackzen.org
 ;;; base64 encoding
+prelude: :std/ssi
 package: std/text
-namespace: std/text/base64
 
 (import :std/error)
 (export #t)
-(extern
+(defruntime
   base64-string->u8vector
   base64-substring->u8vector
   u8vector->base64-string


### PR DESCRIPTION
This to avoid externing the symbols, they really should be define-runtime'd but it was cumbersome before.
Hence the all new .ssi prelude, which also helps restrict what you can do in an .ssi as a step towards normalizing the format.