### PR TITLE
More MOP safety: bind-method! should return void

### DIFF
--- a/src/bootstrap/gerbil/compiler/base~0.scm
+++ b/src/bootstrap/gerbil/compiler/base~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/compiler/base::timestamp 1710943498)
+  (define gerbil/compiler/base::timestamp 1710954837)
   (begin
     (define gxc#current-compile-symbol-table (make-parameter '#f))
     (define gxc#current-compile-runtime-sections (make-parameter '#f))

--- a/src/bootstrap/gerbil/compiler/compile~0.scm
+++ b/src/bootstrap/gerbil/compiler/compile~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/compiler/compile::timestamp 1710943498)
+  (define gerbil/compiler/compile::timestamp 1710954837)
   (begin
     (define gxc#gambit-annotations
       '(not gambit-scheme

--- a/src/bootstrap/gerbil/compiler/driver~0.scm
+++ b/src/bootstrap/gerbil/compiler/driver~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/compiler/driver::timestamp 1710943503)
+  (define gerbil/compiler/driver::timestamp 1710954841)
   (begin
     (define gxc#default-gerbil-gsc
       (path-expand '"gsc" (path-expand '"bin" (path-expand '"~~"))))

--- a/src/bootstrap/gerbil/compiler/method~0.scm
+++ b/src/bootstrap/gerbil/compiler/method~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/compiler/method::timestamp 1710943498)
+  (define gerbil/compiler/method::timestamp 1710954837)
   (begin
     (define gxc#current-compile-method (make-parameter '#f))
     (define gxc#compile-e__0

--- a/src/bootstrap/gerbil/compiler/optimize-ann~0.scm
+++ b/src/bootstrap/gerbil/compiler/optimize-ann~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/compiler/optimize-ann::timestamp 1710943501)
+  (define gerbil/compiler/optimize-ann::timestamp 1710954840)
   (begin
     (declare (inlining-limit 200))
     (define gxc#::optimize-annotated::t

--- a/src/bootstrap/gerbil/compiler/optimize-base~0.scm
+++ b/src/bootstrap/gerbil/compiler/optimize-base~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/compiler/optimize-base::timestamp 1710943499)
+  (define gerbil/compiler/optimize-base::timestamp 1710954837)
   (begin
     (define gxc#current-compile-optimizer-info (make-parameter '#f))
     (define gxc#current-compile-mutators (make-parameter '#f))
@@ -1492,106 +1492,106 @@
                   _g117172_))))))
     (define gxc#!class:::init!::specialize
       (lambda (__klass117040 __method-table117041)
-        (let ((__metaclass117042
+        (let ((__id117042
                (let ((__slot117052
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117040 'metaclass))))
+                        (class-slot-offset __klass117040 'id))))
                  (if __slot117052
                      __slot117052
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'metaclass)))))
-              (__methods117043
+                       (error '"Unknown slot" 'id)))))
+              (__super117043
                (let ((__slot117053
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117040 'methods))))
+                        (class-slot-offset __klass117040 'super))))
                  (if __slot117053
                      __slot117053
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'methods)))))
-              (__id117044
+                       (error '"Unknown slot" 'super)))))
+              (__slots117044
                (let ((__slot117054
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117040 'id))))
+                        (class-slot-offset __klass117040 'slots))))
                  (if __slot117054
                      __slot117054
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'id)))))
-              (__super117045
+                       (error '"Unknown slot" 'slots)))))
+              (__struct?117045
                (let ((__slot117055
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117040 'super))))
+                        (class-slot-offset __klass117040 'struct?))))
                  (if __slot117055
                      __slot117055
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'super)))))
-              (__constructor117046
+                       (error '"Unknown slot" 'struct?)))))
+              (__methods117046
                (let ((__slot117056
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117040 'constructor))))
+                        (class-slot-offset __klass117040 'methods))))
                  (if __slot117056
                      __slot117056
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'constructor)))))
-              (__final?117047
+                       (error '"Unknown slot" 'methods)))))
+              (__metaclass117047
                (let ((__slot117057
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117040 'final?))))
+                        (class-slot-offset __klass117040 'metaclass))))
                  (if __slot117057
                      __slot117057
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'final?)))))
-              (__struct?117048
+                       (error '"Unknown slot" 'metaclass)))))
+              (__constructor117048
                (let ((__slot117058
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117040 'struct?))))
+                        (class-slot-offset __klass117040 'constructor))))
                  (if __slot117058
                      __slot117058
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'struct?)))))
-              (__slots117049
+                       (error '"Unknown slot" 'constructor)))))
+              (__final?117049
                (let ((__slot117059
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117040 'slots))))
+                        (class-slot-offset __klass117040 'final?))))
                  (if __slot117059
                      __slot117059
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'slots)))))
-              (__precedence-list117050
+                       (error '"Unknown slot" 'final?)))))
+              (__fields117050
                (let ((__slot117060
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117040 'precedence-list))))
+                        (class-slot-offset __klass117040 'fields))))
                  (if __slot117060
                      __slot117060
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'precedence-list)))))
-              (__fields117051
+                       (error '"Unknown slot" 'fields)))))
+              (__precedence-list117051
                (let ((__slot117061
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117040 'fields))))
+                        (class-slot-offset __klass117040 'precedence-list))))
                  (if __slot117061
                      __slot117061
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'fields))))))
+                       (error '"Unknown slot" 'precedence-list))))))
           (lambda _g117174_
             (let ((_g117173_
                    (let () (declare (not safe)) (##length _g117174_))))
@@ -1851,7 +1851,7 @@
                                         (##unchecked-structure-set!
                                          _self116749_
                                          _id116750_
-                                         __id117044
+                                         __id117042
                                          __klass117040
                                          '#f))
                                       (let ()
@@ -1859,7 +1859,7 @@
                                         (##unchecked-structure-set!
                                          _self116749_
                                          _super116751_
-                                         __super117045
+                                         __super117043
                                          __klass117040
                                          '#f))
                                       (let ()
@@ -1867,7 +1867,7 @@
                                         (##unchecked-structure-set!
                                          _self116749_
                                          _precedence-list116850_
-                                         __precedence-list117050
+                                         __precedence-list117051
                                          __klass117040
                                          '#f))
                                       (let ()
@@ -1875,7 +1875,7 @@
                                         (##unchecked-structure-set!
                                          _self116749_
                                          _slots116752_
-                                         __slots117049
+                                         __slots117044
                                          __klass117040
                                          '#f))
                                       (let ()
@@ -1883,7 +1883,7 @@
                                         (##unchecked-structure-set!
                                          _self116749_
                                          _fields116853_
-                                         __fields117051
+                                         __fields117050
                                          __klass117040
                                          '#f))
                                       (let ()
@@ -1891,7 +1891,7 @@
                                         (##unchecked-structure-set!
                                          _self116749_
                                          _ctor-method116844_
-                                         __constructor117046
+                                         __constructor117048
                                          __klass117040
                                          '#f))
                                       (let ()
@@ -1899,7 +1899,7 @@
                                         (##unchecked-structure-set!
                                          _self116749_
                                          _struct?116754_
-                                         __struct?117048
+                                         __struct?117045
                                          __klass117040
                                          '#f))
                                       (let ()
@@ -1907,7 +1907,7 @@
                                         (##unchecked-structure-set!
                                          _self116749_
                                          _final?116755_
-                                         __final?117047
+                                         __final?117049
                                          __klass117040
                                          '#f))
                                       (let ()
@@ -1915,7 +1915,7 @@
                                         (##unchecked-structure-set!
                                          _self116749_
                                          _metaclass116757_
-                                         __metaclass117042
+                                         __metaclass117047
                                          __klass117040
                                          '#f)))))))
                             _g117174_))
@@ -1937,7 +1937,7 @@
                                 (##unchecked-structure-set!
                                  _self116856_
                                  _id116857_
-                                 __id117044
+                                 __id117042
                                  __klass117040
                                  '#f))
                               (let ()
@@ -1945,7 +1945,7 @@
                                 (##unchecked-structure-set!
                                  _self116856_
                                  _super116858_
-                                 __super117045
+                                 __super117043
                                  __klass117040
                                  '#f))
                               (let ()
@@ -1953,7 +1953,7 @@
                                 (##unchecked-structure-set!
                                  _self116856_
                                  _precedence-list116859_
-                                 __precedence-list117050
+                                 __precedence-list117051
                                  __klass117040
                                  '#f))
                               (let ()
@@ -1961,7 +1961,7 @@
                                 (##unchecked-structure-set!
                                  _self116856_
                                  _slots116860_
-                                 __slots117049
+                                 __slots117044
                                  __klass117040
                                  '#f))
                               (let ()
@@ -1969,7 +1969,7 @@
                                 (##unchecked-structure-set!
                                  _self116856_
                                  _fields116861_
-                                 __fields117051
+                                 __fields117050
                                  __klass117040
                                  '#f))
                               (let ()
@@ -1977,7 +1977,7 @@
                                 (##unchecked-structure-set!
                                  _self116856_
                                  _constructor116862_
-                                 __constructor117046
+                                 __constructor117048
                                  __klass117040
                                  '#f))
                               (let ()
@@ -1985,7 +1985,7 @@
                                 (##unchecked-structure-set!
                                  _self116856_
                                  _struct?116863_
-                                 __struct?117048
+                                 __struct?117045
                                  __klass117040
                                  '#f))
                               (let ()
@@ -1993,7 +1993,7 @@
                                 (##unchecked-structure-set!
                                  _self116856_
                                  _final?116864_
-                                 __final?117047
+                                 __final?117049
                                  __klass117040
                                  '#f))
                               (let ()
@@ -2001,7 +2001,7 @@
                                 (##unchecked-structure-set!
                                  _self116856_
                                  _metaclass116866_
-                                 __metaclass117042
+                                 __metaclass117047
                                  __klass117040
                                  '#f))
                               (if _methods116867_
@@ -2014,7 +2014,7 @@
                                     (##unchecked-structure-set!
                                      _self116856_
                                      __tmp117194
-                                     __methods117043
+                                     __methods117046
                                      __klass117040
                                      '#f))
                                   '#!void))
@@ -2294,26 +2294,26 @@
                      (let ()
                        (declare (not safe))
                        (error '"Unknown slot" 'id)))))
-              (__checked?117073
+              (__slot117073
                (let ((__slot117076
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117070 'checked?))))
+                        (class-slot-offset __klass117070 'slot))))
                  (if __slot117076
                      __slot117076
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'checked?)))))
-              (__slot117074
+                       (error '"Unknown slot" 'slot)))))
+              (__checked?117074
                (let ((__slot117077
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117070 'slot))))
+                        (class-slot-offset __klass117070 'checked?))))
                  (if __slot117077
                      __slot117077
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'slot))))))
+                       (error '"Unknown slot" 'checked?))))))
           (lambda (_self116260_ _id116261_ _slot116262_ _checked?116263_)
             (let ()
               (declare (not safe))
@@ -2328,7 +2328,7 @@
               (##unchecked-structure-set!
                _self116260_
                _slot116262_
-               __slot117074
+               __slot117073
                __klass117070
                '#f))
             (let ()
@@ -2336,7 +2336,7 @@
               (##unchecked-structure-set!
                _self116260_
                _checked?116263_
-               __checked?117073
+               __checked?117074
                __klass117070
                '#f))))))
     (let ()
@@ -2369,26 +2369,26 @@
                      (let ()
                        (declare (not safe))
                        (error '"Unknown slot" 'id)))))
-              (__checked?117081
+              (__slot117081
                (let ((__slot117084
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117078 'checked?))))
+                        (class-slot-offset __klass117078 'slot))))
                  (if __slot117084
                      __slot117084
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'checked?)))))
-              (__slot117082
+                       (error '"Unknown slot" 'slot)))))
+              (__checked?117082
                (let ((__slot117085
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass117078 'slot))))
+                        (class-slot-offset __klass117078 'checked?))))
                  (if __slot117085
                      __slot117085
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'slot))))))
+                       (error '"Unknown slot" 'checked?))))))
           (lambda (_self116133_ _id116134_ _slot116135_ _checked?116136_)
             (let ()
               (declare (not safe))
@@ -2403,7 +2403,7 @@
               (##unchecked-structure-set!
                _self116133_
                _slot116135_
-               __slot117082
+               __slot117081
                __klass117078
                '#f))
             (let ()
@@ -2411,7 +2411,7 @@
               (##unchecked-structure-set!
                _self116133_
                _checked?116136_
-               __checked?117081
+               __checked?117082
                __klass117078
                '#f))))))
     (let ()

--- a/src/bootstrap/gerbil/compiler/optimize-call~0.scm
+++ b/src/bootstrap/gerbil/compiler/optimize-call~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/compiler/optimize-call::timestamp 1710943503)
+  (define gerbil/compiler/optimize-call::timestamp 1710954841)
   (begin
     (define gxc#::optimize-call::t
       (let ((__tmp155049 (list gxc#::basic-xform::t))
@@ -3036,26 +3036,26 @@
                      (let ()
                        (declare (not safe))
                        (error '"Unknown slot" 'id)))))
-              (__checked?154763
+              (__slot154763
                (let ((__slot154766
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass154760 'checked?))))
+                        (class-slot-offset __klass154760 'slot))))
                  (if __slot154766
                      __slot154766
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'checked?)))))
-              (__slot154764
+                       (error '"Unknown slot" 'slot)))))
+              (__checked?154764
                (let ((__slot154767
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass154760 'slot))))
+                        (class-slot-offset __klass154760 'checked?))))
                  (if __slot154767
                      __slot154767
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'slot))))))
+                       (error '"Unknown slot" 'checked?))))))
           (lambda (_self154086_ _ctx154087_ _stx154088_ _args154089_)
             (let* ((_g154091154101_
                     (lambda (_g154092154098_)
@@ -3105,7 +3105,7 @@
                                                       (declare (not safe))
                                                       (##unchecked-structure-ref
                                                        _self154086_
-                                                       __slot154764
+                                                       __slot154763
                                                        __klass154760
                                                        '#f))))
                                                (declare (not safe))
@@ -3131,7 +3131,7 @@
                          (not safe))
                        (##unchecked-structure-ref
                         _self154086_
-                        __checked?154763
+                        __checked?154764
                         __klass154760
                         '#f))
                      '%#struct-direct-ref
@@ -3187,7 +3187,7 @@
                            (declare (not safe))
                            (##unchecked-structure-ref
                             _self154086_
-                            __checked?154763
+                            __checked?154764
                             __klass154760
                             '#f))
                          '%#struct-ref
@@ -3238,7 +3238,7 @@
                          (not safe))
                        (##unchecked-structure-ref
                         _self154086_
-                        __slot154764
+                        __slot154763
                         __klass154760
                         '#f))))
                 (declare (not safe))
@@ -3253,7 +3253,7 @@
                                     (declare (not safe))
                                     (##unchecked-structure-ref
                                      _self154086_
-                                     __checked?154763
+                                     __checked?154764
                                      __klass154760
                                      '#f))
                                   '%#struct-ref
@@ -3300,7 +3300,7 @@
                                                            (declare (not safe))
                                                            (##unchecked-structure-ref
                                                             _self154086_
-                                                            __checked?154763
+                                                            __checked?154764
                                                             __klass154760
                                                             '#f))
                                                          (let ((__tmp155561
@@ -3447,7 +3447,7 @@
                                              (declare (not safe))
                                              (##unchecked-structure-ref
                                               _self154086_
-                                              __slot154764
+                                              __slot154763
                                               __klass154760
                                               '#f))))
                                       (declare (not safe))
@@ -3503,7 +3503,7 @@
                             (declare (not safe))
                             (##unchecked-structure-ref
                              _self154086_
-                             __slot154764
+                             __slot154763
                              __klass154760
                              '#f))))
                      (declare (not safe))
@@ -4046,26 +4046,26 @@
                      (let ()
                        (declare (not safe))
                        (error '"Unknown slot" 'id)))))
-              (__checked?154771
+              (__slot154771
                (let ((__slot154774
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass154768 'checked?))))
+                        (class-slot-offset __klass154768 'slot))))
                  (if __slot154774
                      __slot154774
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'checked?)))))
-              (__slot154772
+                       (error '"Unknown slot" 'slot)))))
+              (__checked?154772
                (let ((__slot154775
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass154768 'slot))))
+                        (class-slot-offset __klass154768 'checked?))))
                  (if __slot154775
                      __slot154775
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'slot))))))
+                       (error '"Unknown slot" 'checked?))))))
           (lambda (_self153890_ _ctx153891_ _stx153892_ _args153893_)
             (let* ((_g153895153909_
                     (lambda (_g153896153906_)
@@ -4132,7 +4132,7 @@
                                                                 (not safe))
                                                               (##unchecked-structure-ref
                                                                _self153890_
-                                                               __slot154772
+                                                               __slot154771
                                                                __klass154768
                                                                '#f))))
                                                        (declare (not safe))
@@ -4163,7 +4163,7 @@
                                (declare (not safe))
                                (##unchecked-structure-ref
                                 _self153890_
-                                __checked?154771
+                                __checked?154772
                                 __klass154768
                                 '#f))
                              '%#struct-direct-set!
@@ -4221,7 +4221,7 @@
                                    (declare (not safe))
                                    (##unchecked-structure-ref
                                     _self153890_
-                                    __checked?154771
+                                    __checked?154772
                                     __klass154768
                                     '#f))
                                  '%#struct-set!
@@ -4271,7 +4271,7 @@
                                (declare (not safe))
                                (##unchecked-structure-ref
                                 _self153890_
-                                __slot154772
+                                __slot154771
                                 __klass154768
                                 '#f))))
                         (declare (not safe))
@@ -4286,7 +4286,7 @@
                                             (declare (not safe))
                                             (##unchecked-structure-ref
                                              _self153890_
-                                             __checked?154771
+                                             __checked?154772
                                              __klass154768
                                              '#f))
                                           '%#struct-set!
@@ -4344,7 +4344,7 @@
                            (declare (not safe))
                            (##unchecked-structure-ref
                             _self153890_
-                            __checked?154771
+                            __checked?154772
                             __klass154768
                             '#f))
                          (let ((__tmp155744
@@ -4492,7 +4492,7 @@
                                                      (declare (not safe))
                                                      (##unchecked-structure-ref
                                                       _self153890_
-                                                      __slot154772
+                                                      __slot154771
                                                       __klass154768
                                                       '#f))))
                                               (declare (not safe))
@@ -4552,7 +4552,7 @@
                                     (declare (not safe))
                                     (##unchecked-structure-ref
                                      _self153890_
-                                     __slot154772
+                                     __slot154771
                                      __klass154768
                                      '#f))))
                              (declare (not safe))

--- a/src/bootstrap/gerbil/compiler/optimize-spec~0.scm
+++ b/src/bootstrap/gerbil/compiler/optimize-spec~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/compiler/optimize-spec::timestamp 1710943500)
+  (define gerbil/compiler/optimize-spec::timestamp 1710954839)
   (begin
     (define gxc#::generate-method-specializers::t
       (let ((__tmp137217 (list gxc#::identity::t))

--- a/src/bootstrap/gerbil/compiler/optimize-top~0.scm
+++ b/src/bootstrap/gerbil/compiler/optimize-top~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/compiler/optimize-top::timestamp 1710943499)
+  (define gerbil/compiler/optimize-top::timestamp 1710954838)
   (begin
     (define gxc#::collect-top-level-type-info::t
       (let ((__tmp130632 (list gxc#::void::t))

--- a/src/bootstrap/gerbil/compiler/optimize-xform~0.scm
+++ b/src/bootstrap/gerbil/compiler/optimize-xform~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/compiler/optimize-xform::timestamp 1710943499)
+  (define gerbil/compiler/optimize-xform::timestamp 1710954837)
   (begin
     (define gxc#::collect-mutators::t
       (let ((__tmp119799 (list gxc#::void::t))

--- a/src/bootstrap/gerbil/compiler/optimize~0.scm
+++ b/src/bootstrap/gerbil/compiler/optimize~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/compiler/optimize::timestamp 1710943503)
+  (define gerbil/compiler/optimize::timestamp 1710954841)
   (begin
     (define gxc#optimizer-info-init!
       (lambda ()

--- a/src/bootstrap/gerbil/core/macro-object~0.scm
+++ b/src/bootstrap/gerbil/core/macro-object~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/core/macro-object::timestamp 1710943495)
+  (define gerbil/core/macro-object::timestamp 1710954834)
   (begin
     (define gerbil/core/macro-object#macro-object::t
       (let ((__tmp36222 (list)))

--- a/src/bootstrap/gerbil/core/match~1.scm
+++ b/src/bootstrap/gerbil/core/match~1.scm
@@ -70,36 +70,36 @@
     (##structure gx#syntax-quote::t 'and #f (gx#current-expander-context) '()))
   (define |gerbil/core/match[1]#_g48253_|
     (##structure gx#syntax-quote::t '? #f (gx#current-expander-context) '()))
-  (define |gerbil/core/match[1]#_g48671_|
+  (define |gerbil/core/match[1]#_g48646_|
     (##structure
      gx#syntax-quote::t
      'else
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/match[1]#_g48755_|
+  (define |gerbil/core/match[1]#_g48730_|
     (##structure
      gx#syntax-quote::t
      'else
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/match[1]#_g48775_|
+  (define |gerbil/core/match[1]#_g48750_|
     (##structure
      gx#syntax-quote::t
      '<...>
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/match[1]#_g48776_|
+  (define |gerbil/core/match[1]#_g48751_|
     (##structure gx#syntax-quote::t '<> #f (gx#current-expander-context) '()))
-  (define |gerbil/core/match[1]#_g48905_|
+  (define |gerbil/core/match[1]#_g48880_|
     (##structure gx#syntax-quote::t '=> #f (gx#current-expander-context) '()))
-  (define |gerbil/core/match[1]#_g48906_|
+  (define |gerbil/core/match[1]#_g48881_|
     (##structure gx#syntax-quote::t '=> #f (gx#current-expander-context) '()))
-  (define |gerbil/core/match[1]#_g48907_|
+  (define |gerbil/core/match[1]#_g48882_|
     (##structure gx#syntax-quote::t 'not #f (gx#current-expander-context) '()))
-  (define |gerbil/core/match[1]#_g48908_|
+  (define |gerbil/core/match[1]#_g48883_|
     (##structure gx#syntax-quote::t 'or #f (gx#current-expander-context) '()))
   (define |gerbil/core/match[1]#_g48909_|
     (##structure gx#syntax-quote::t 'and #f (gx#current-expander-context) '()))
@@ -5078,9 +5078,9 @@
                                          (declare (not safe))
                                          (_struct-field-accessors37465_
                                           _info37680_)))
-                                      (__tmp48611
-                                       (let ((__tmp48615
-                                              (let ((__tmp48617
+                                      (__tmp48586
+                                       (let ((__tmp48590
+                                              (let ((__tmp48592
                                                      (let ((__obj48158
                                                             _info37680_))
                                                        (if (let ()
@@ -5101,14 +5101,14 @@
                                                             gerbil/core/mop~MOP-2#class-type-info::t
                                                             __obj48158
                                                             'predicate))))
-                                                    (__tmp48616
+                                                    (__tmp48591
                                                      (let ()
                                                        (declare (not safe))
                                                        (cons _tgt37682_ '()))))
                                                 (declare (not safe))
-                                                (cons __tmp48617 __tmp48616)))
-                                             (__tmp48612
-                                              (let ((__tmp48614
+                                                (cons __tmp48592 __tmp48591)))
+                                             (__tmp48587
+                                              (let ((__tmp48589
                                                      (let ()
                                                        (declare (not safe))
                                                        (_generate-simple-struct-body37464_
@@ -5117,21 +5117,21 @@
                                                         _L37788_
                                                         _K37684_
                                                         _E37685_)))
-                                                    (__tmp48613
+                                                    (__tmp48588
                                                      (let ()
                                                        (declare (not safe))
                                                        (cons _E37685_ '()))))
                                                 (declare (not safe))
-                                                (cons __tmp48614 __tmp48613))))
+                                                (cons __tmp48589 __tmp48588))))
                                          (declare (not safe))
-                                         (cons __tmp48615 __tmp48612))))
+                                         (cons __tmp48590 __tmp48587))))
                                  (declare (not safe))
-                                 (cons 'if __tmp48611))))
+                                 (cons 'if __tmp48586))))
                             (___kont4740947410_
                              (lambda (_L37742_)
-                               (let ((__tmp48618
-                                      (let ((__tmp48622
-                                             (let ((__tmp48624
+                               (let ((__tmp48593
+                                      (let ((__tmp48597
+                                             (let ((__tmp48599
                                                     (let ((__obj48159
                                                            _info37680_))
                                                       (if (let ()
@@ -5152,14 +5152,14 @@
                                                            gerbil/core/mop~MOP-2#class-type-info::t
                                                            __obj48159
                                                            'predicate))))
-                                                   (__tmp48623
+                                                   (__tmp48598
                                                     (let ()
                                                       (declare (not safe))
                                                       (cons _tgt37682_ '()))))
                                                (declare (not safe))
-                                               (cons __tmp48624 __tmp48623)))
-                                            (__tmp48619
-                                             (let ((__tmp48621
+                                               (cons __tmp48599 __tmp48598)))
+                                            (__tmp48594
+                                             (let ((__tmp48596
                                                     (let ()
                                                       (declare (not safe))
                                                       (_generate-list-vector37462_
@@ -5168,16 +5168,16 @@
                                                        'struct->list
                                                        _K37684_
                                                        _E37685_)))
-                                                   (__tmp48620
+                                                   (__tmp48595
                                                     (let ()
                                                       (declare (not safe))
                                                       (cons _E37685_ '()))))
                                                (declare (not safe))
-                                               (cons __tmp48621 __tmp48620))))
+                                               (cons __tmp48596 __tmp48595))))
                                         (declare (not safe))
-                                        (cons __tmp48622 __tmp48619))))
+                                        (cons __tmp48597 __tmp48594))))
                                  (declare (not safe))
-                                 (cons 'if __tmp48618)))))
+                                 (cons 'if __tmp48593)))))
                         (if (gx#stx-pair? ___stx4740447405_)
                             (let ((_e3769337764_
                                    (gx#syntax-e ___stx4740447405_)))
@@ -5300,45 +5300,45 @@
                                              'name))))
                                      (let ((_$tgt37672_ (gx#genident 'e))
                                            (_getf37674_ (car _fields37612_)))
-                                       (let ((__tmp48625
-                                              (let ((__tmp48630
-                                                     (let ((__tmp48631
-                                                            (let ((__tmp48632
+                                       (let ((__tmp48600
+                                              (let ((__tmp48605
+                                                     (let ((__tmp48606
+                                                            (let ((__tmp48607
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                           (let ((__tmp48633
-                                  (let ((__tmp48634
+                           (let ((__tmp48608
+                                  (let ((__tmp48609
                                          (let ()
                                            (declare (not safe))
                                            (cons _tgt37602_ '()))))
                                     (declare (not safe))
-                                    (cons _getf37674_ __tmp48634))))
+                                    (cons _getf37674_ __tmp48609))))
                              (declare (not safe))
-                             (cons __tmp48633 '()))))
+                             (cons __tmp48608 '()))))
                       (declare (not safe))
-                      (cons _$tgt37672_ __tmp48632))))
+                      (cons _$tgt37672_ __tmp48607))))
                (declare (not safe))
-               (cons __tmp48631 '())))
+               (cons __tmp48606 '())))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-                                                    (__tmp48626
-                                                     (let ((__tmp48627
-                                                            (let ((__tmp48628
+                                                    (__tmp48601
+                                                     (let ((__tmp48602
+                                                            (let ((__tmp48603
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                           (let ((__tmp48629 (cdr _fields37612_)))
+                           (let ((__tmp48604 (cdr _fields37612_)))
                              (declare (not safe))
-                             (_recur37607_ _L37655_ __tmp48629))))
+                             (_recur37607_ _L37655_ __tmp48604))))
                       (declare (not safe))
                       (_generate137458_
                        _$tgt37672_
                        _L37657_
-                       __tmp48628
+                       __tmp48603
                        _E37605_))))
                (declare (not safe))
-               (cons __tmp48627 '()))))
+               (cons __tmp48602 '()))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                 (declare (not safe))
-                                                (cons __tmp48630 __tmp48626))))
+                                                (cons __tmp48605 __tmp48601))))
                                          (declare (not safe))
-                                         (cons 'let __tmp48625))))))
+                                         (cons 'let __tmp48600))))))
                               (___kont4745947460_ (lambda () _K37604_)))
                           (if (gx#stx-pair? ___stx4745447455_)
                               (let ((_e3762137645_
@@ -5364,7 +5364,7 @@
                       (if (let () (declare (not safe)) (null? _next37587_))
                           '()
                           (let ((_ti37590_ (car _next37587_)))
-                            (append (let ((__tmp48635
+                            (append (let ((__tmp48610
                                            (map gx#syntax-local-value
                                                 (let ((__obj48161 _ti37590_))
                                                   (if (let ()
@@ -5384,10 +5384,10 @@
                                                        __obj48161
                                                        'super))))))
                                       (declare (not safe))
-                                      (_recur37584_ __tmp48635))
+                                      (_recur37584_ __tmp48610))
                                     (map (lambda (_slot37593_)
                                            (let ((_$e37596_
-                                                  (let ((__tmp48636
+                                                  (let ((__tmp48611
                                                          (let ((__obj48162
                                                                 _ti37590_))
                                                            (if (let ()
@@ -5411,7 +5411,7 @@
                                                     (declare (not safe))
                                                     (assgetq__0
                                                      _slot37593_
-                                                     __tmp48636))))
+                                                     __tmp48611))))
                                              (if _$e37596_
                                                  _$e37596_
                                                  (gx#raise-syntax-error
@@ -5443,9 +5443,9 @@
                            _body37577_
                            _K37578_
                            _E37579_)
-                    (let ((__tmp48637
-                           (let ((__tmp48641
-                                  (let ((__tmp48643
+                    (let ((__tmp48612
+                           (let ((__tmp48616
+                                  (let ((__tmp48618
                                          (let ((__obj48164 _info37574_))
                                            (if (let ()
                                                  (declare (not safe))
@@ -5463,14 +5463,14 @@
                                                 gerbil/core/mop~MOP-2#class-type-info::t
                                                 __obj48164
                                                 'predicate))))
-                                        (__tmp48642
+                                        (__tmp48617
                                          (let ()
                                            (declare (not safe))
                                            (cons _tgt37576_ '()))))
                                     (declare (not safe))
-                                    (cons __tmp48643 __tmp48642)))
-                                 (__tmp48638
-                                  (let ((__tmp48640
+                                    (cons __tmp48618 __tmp48617)))
+                                 (__tmp48613
+                                  (let ((__tmp48615
                                          (let ()
                                            (declare (not safe))
                                            (_generate-class-body37467_
@@ -5479,16 +5479,16 @@
                                             _body37577_
                                             _K37578_
                                             _E37579_)))
-                                        (__tmp48639
+                                        (__tmp48614
                                          (let ()
                                            (declare (not safe))
                                            (cons _E37579_ '()))))
                                     (declare (not safe))
-                                    (cons __tmp48640 __tmp48639))))
+                                    (cons __tmp48615 __tmp48614))))
                              (declare (not safe))
-                             (cons __tmp48641 __tmp48638))))
+                             (cons __tmp48616 __tmp48613))))
                       (declare (not safe))
-                      (cons 'if __tmp48637))))
+                      (cons 'if __tmp48612))))
                  (_generate-class-body37467_
                   (lambda (_info37469_
                            _tgt37471_
@@ -5506,11 +5506,11 @@
                         (let ((___kont4747347474_
                                (lambda (_L37537_ _L37539_ _L37540_)
                                  (let ((_$e37560_
-                                        (let ((__tmp48645
+                                        (let ((__tmp48620
                                                (string->symbol
                                                 (keyword->string
                                                  (gx#stx-e _L37540_))))
-                                              (__tmp48644
+                                              (__tmp48619
                                                (let ((__obj48165 _info37469_))
                                                  (if (let ()
                                                        (declare (not safe))
@@ -5529,31 +5529,31 @@
                                                       __obj48165
                                                       'unchecked-accessors)))))
                                           (declare (not safe))
-                                          (assgetq__0 __tmp48645 __tmp48644))))
+                                          (assgetq__0 __tmp48620 __tmp48619))))
                                    (if _$e37560_
                                        ((lambda (_getf37564_)
                                           (let* ((_$tgt37567_ (gx#genident 'e))
-                                                 (__tmp48646
-                                                  (let ((__tmp48650
-                                                         (let ((__tmp48651
-                                                                (let ((__tmp48652
+                                                 (__tmp48621
+                                                  (let ((__tmp48625
+                                                         (let ((__tmp48626
+                                                                (let ((__tmp48627
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                               (let ((__tmp48653
-                                      (let ((__tmp48654
+                               (let ((__tmp48628
+                                      (let ((__tmp48629
                                              (let ()
                                                (declare (not safe))
                                                (cons _tgt37471_ '()))))
                                         (declare (not safe))
-                                        (cons _getf37564_ __tmp48654))))
+                                        (cons _getf37564_ __tmp48629))))
                                  (declare (not safe))
-                                 (cons __tmp48653 '()))))
+                                 (cons __tmp48628 '()))))
                           (declare (not safe))
-                          (cons _$tgt37567_ __tmp48652))))
+                          (cons _$tgt37567_ __tmp48627))))
                    (declare (not safe))
-                   (cons __tmp48651 '())))
-                (__tmp48647
-                 (let ((__tmp48648
-                        (let ((__tmp48649
+                   (cons __tmp48626 '())))
+                (__tmp48622
+                 (let ((__tmp48623
+                        (let ((__tmp48624
                                (let ()
                                  (declare (not safe))
                                  (_recur37476_ _L37537_))))
@@ -5561,16 +5561,16 @@
                           (_generate137458_
                            _$tgt37567_
                            _L37539_
-                           __tmp48649
+                           __tmp48624
                            _E37474_))))
                    (declare (not safe))
-                   (cons __tmp48648 '()))))
+                   (cons __tmp48623 '()))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                     (declare (not safe))
-                                                    (cons __tmp48650
-                                                          __tmp48647))))
+                                                    (cons __tmp48625
+                                                          __tmp48622))))
                                             (declare (not safe))
-                                            (cons 'let __tmp48646)))
+                                            (cons 'let __tmp48621)))
                                         _$e37560_)
                                        (gx#raise-syntax-error
                                         '#f
@@ -5635,33 +5635,33 @@
                                    (let ((___kont4749547496_
                                           (lambda (_L37428_)
                                             (if (gx#stx-null? _L37324_)
-                                                (let ((__tmp48655
-                                                       (let ((__tmp48660
+                                                (let ((__tmp48630
+                                                       (let ((__tmp48635
                                                               (gx#genident
                                                                'else))
-                                                             (__tmp48656
-                                                              (let ((__tmp48657
+                                                             (__tmp48631
+                                                              (let ((__tmp48632
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                             (let ((__tmp48658
+                             (let ((__tmp48633
                                     (gx#stx-wrap-source
-                                     (let ((__tmp48659
+                                     (let ((__tmp48634
                                             (gx#datum->syntax '#f 'begin)))
                                        (declare (not safe))
-                                       (cons __tmp48659 _L37428_))
+                                       (cons __tmp48634 _L37428_))
                                      (let ((_$e37439_
                                             (gx#stx-source _L37326_)))
                                        (if _$e37439_
                                            _$e37439_
                                            (gx#stx-source _stx36347_))))))
                                (declare (not safe))
-                               (cons __tmp48658 '()))))
+                               (cons __tmp48633 '()))))
                         (declare (not safe))
-                        (cons '#f __tmp48657))))
+                        (cons '#f __tmp48632))))
                  (declare (not safe))
-                 (cons __tmp48660 __tmp48656))))
+                 (cons __tmp48635 __tmp48631))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                   (declare (not safe))
-                                                  (cons __tmp48655 _r37281_))
+                                                  (cons __tmp48630 _r37281_))
                                                 (gx#raise-syntax-error
                                                  '#f
                                                  '"bad syntax; misplaced else"
@@ -5669,13 +5669,13 @@
                                                  _L37326_))))
                                          (___kont4749747498_
                                           (lambda (_L37387_ _L37389_)
-                                            (let ((__tmp48661
-                                                   (let ((__tmp48662
-                                                          (let ((__tmp48668
+                                            (let ((__tmp48636
+                                                   (let ((__tmp48637
+                                                          (let ((__tmp48643
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                          (gx#genident 'try-match))
-                        (__tmp48663
-                         (let ((__tmp48667
+                        (__tmp48638
+                         (let ((__tmp48642
                                 (gx#stx-map
                                  (lambda (_g3740137403_)
                                    (let ()
@@ -5684,32 +5684,32 @@
                                       _g3740137403_
                                       _stx36347_)))
                                  _L37389_))
-                               (__tmp48664
-                                (let ((__tmp48665
+                               (__tmp48639
+                                (let ((__tmp48640
                                        (gx#stx-wrap-source
-                                        (let ((__tmp48666
+                                        (let ((__tmp48641
                                                (gx#datum->syntax '#f 'begin)))
                                           (declare (not safe))
-                                          (cons __tmp48666 _L37387_))
+                                          (cons __tmp48641 _L37387_))
                                         (let ((_$e37407_
                                                (gx#stx-source _L37326_)))
                                           (if _$e37407_
                                               _$e37407_
                                               (gx#stx-source _stx36347_))))))
                                   (declare (not safe))
-                                  (cons __tmp48665 '()))))
+                                  (cons __tmp48640 '()))))
                            (declare (not safe))
-                           (cons __tmp48667 __tmp48664))))
+                           (cons __tmp48642 __tmp48639))))
                     (declare (not safe))
-                    (cons __tmp48668 __tmp48663))))
+                    (cons __tmp48643 __tmp48638))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (declare (not safe))
-                                                     (cons __tmp48662
+                                                     (cons __tmp48637
                                                            _r37281_))))
                                               (declare (not safe))
                                               (_lp37276_
                                                _L37324_
-                                               __tmp48661))))
+                                               __tmp48636))))
                                          (___kont4749947500_
                                           (lambda ()
                                             (gx#raise-syntax-error
@@ -5730,11 +5730,11 @@
                                                                _hd-len37273_)
                                                           (gx#stx-list?
                                                            _L37387_)
-                                                          (let ((__tmp48669
+                                                          (let ((__tmp48644
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                          (gx#stx-null? _L37387_)))
                     (declare (not safe))
-                    (not __tmp48669)))
+                    (not __tmp48644)))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (___kont4749747498_
                                                       _L37387_
@@ -5747,11 +5747,11 @@
                                                (let ((_L37428_ _tl3734637425_))
                                                  (if (and (gx#stx-list?
                                                            _L37428_)
-                                                          (let ((__tmp48670
+                                                          (let ((__tmp48645
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                          (gx#stx-null? _L37428_)))
                     (declare (not safe))
-                    (not __tmp48670)))
+                    (not __tmp48645)))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (___kont4749547496_
                                                       _L37428_)
@@ -5774,7 +5774,7 @@
                                                (if (gx#identifier?
                                                     _hd3734737422_)
                                                    (if (gx#free-identifier=?
-                                                        |gerbil/core/match[1]#_g48671_|
+                                                        |gerbil/core/match[1]#_g48646_|
                                                         _hd3734737422_)
                                                        (___match4751147512_
                                                         _e3734837418_
@@ -5827,36 +5827,36 @@
                                            (lambda (_g3708937109_)
                                              (if (gx#stx-pair/null?
                                                   _g3708937109_)
-                                                 (let ((_g48672_
+                                                 (let ((_g48647_
                                                         (gx#syntax-split-splice
                                                          _g3708937109_
                                                          '0)))
                                                    (begin
-                                                     (let ((_g48673_
+                                                     (let ((_g48648_
                                                             (let ()
                                                               (declare
                                                                 (not safe))
                                                               (if (##values?
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                           _g48672_)
-                          (##vector-length _g48672_)
+                           _g48647_)
+                          (##vector-length _g48647_)
                           1))))
-               (if (not (let () (declare (not safe)) (##fx= _g48673_ 2)))
-                   (error "Context expects 2 values" _g48673_)))
+               (if (not (let () (declare (not safe)) (##fx= _g48648_ 2)))
+                   (error "Context expects 2 values" _g48648_)))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (let ((_target3709137112_
                                                             (let ()
                                                               (declare
                                                                 (not safe))
                                                               (##vector-ref
-                                                               _g48672_
+                                                               _g48647_
                                                                0)))
                                                            (_tl3709337115_
                                                             (let ()
                                                               (declare
                                                                 (not safe))
                                                               (##vector-ref
-                                                               _g48672_
+                                                               _g48647_
                                                                1))))
                                                        (if (gx#stx-null?
                                                             _tl3709337115_)
@@ -5874,7 +5874,7 @@
                                             (let ()
                                               (declare (not safe))
                                               (##cdr _e3709537128_))))
-                                       (let ((__tmp48696
+                                       (let ((__tmp48671
                                               (let ()
                                                 (declare (not safe))
                                                 (cons _lp-hd3709637132_
@@ -5882,7 +5882,7 @@
                                          (declare (not safe))
                                          (_loop3709437118_
                                           _lp-tl3709737135_
-                                          __tmp48696))))
+                                          __tmp48671))))
                                    (let ((_target3709937138_
                                           (reverse _target3709837125_)))
                                      ((lambda (_L37142_)
@@ -5919,80 +5919,80 @@
                                           ((lambda (_L37230_)
                                              (let ()
                                                (let ()
-                                                 (let ((__tmp48677
+                                                 (let ((__tmp48652
                                                         (gx#datum->syntax
                                                          '#f
                                                          'begin-annotation))
-                                                       (__tmp48674
-                                                        (let ((__tmp48676
+                                                       (__tmp48649
+                                                        (let ((__tmp48651
                                                                (gx#datum->syntax
                                                                 '#f
                                                                 '@match))
-                                                              (__tmp48675
+                                                              (__tmp48650
                                                                (let ()
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                          (declare (not safe))
                          (cons _L37230_ '()))))
                   (declare (not safe))
-                  (cons __tmp48676 __tmp48675))))
+                  (cons __tmp48651 __tmp48650))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                    (declare (not safe))
-                                                   (cons __tmp48677
-                                                         __tmp48674)))))
+                                                   (cons __tmp48652
+                                                         __tmp48649)))))
                                            _g3721637227_)))
-                                       (__tmp48678
+                                       (__tmp48653
                                         (gx#stx-wrap-source
-                                         (let ((__tmp48684
+                                         (let ((__tmp48659
                                                 (gx#datum->syntax '#f 'let))
-                                               (__tmp48679
-                                                (let ((__tmp48681
-                                                       (let ((__tmp48682
-                                                              (let ((__tmp48683
+                                               (__tmp48654
+                                                (let ((__tmp48656
+                                                       (let ((__tmp48657
+                                                              (let ((__tmp48658
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                              (let ()
                                (declare (not safe))
                                (cons _L37174_ '()))))
                         (declare (not safe))
-                        (cons _L37076_ __tmp48683))))
+                        (cons _L37076_ __tmp48658))))
                  (declare (not safe))
-                 (cons __tmp48682 '())))
-              (__tmp48680 (let () (declare (not safe)) (cons _L37202_ '()))))
+                 (cons __tmp48657 '())))
+              (__tmp48655 (let () (declare (not safe)) (cons _L37202_ '()))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                   (declare (not safe))
-                                                  (cons __tmp48681
-                                                        __tmp48680))))
+                                                  (cons __tmp48656
+                                                        __tmp48655))))
                                            (declare (not safe))
-                                           (cons __tmp48684 __tmp48679))
+                                           (cons __tmp48659 __tmp48654))
                                          (gx#stx-source _stx36347_))))
                                   (declare (not safe))
-                                  (_g3721437245_ __tmp48678))))
+                                  (_g3721437245_ __tmp48653))))
                             _g3718837199_)))
-                        (__tmp48685
-                         (let ((__tmp48686
+                        (__tmp48660
+                         (let ((__tmp48661
                                 (let ()
                                   (declare (not safe))
                                   (cons _L37076_ '()))))
                            (declare (not safe))
-                           (_generate-clauses36355_ _body37058_ __tmp48686))))
+                           (_generate-clauses36355_ _body37058_ __tmp48661))))
                    (declare (not safe))
-                   (_g3718637249_ __tmp48685))))
+                   (_g3718637249_ __tmp48660))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      _g3716037171_)))
-                                                 (__tmp48687
+                                                 (__tmp48662
                                                   (gx#stx-wrap-source
-                                                   (let ((__tmp48695
+                                                   (let ((__tmp48670
                                                           (gx#datum->syntax
                                                            '#f
                                                            'lambda))
-                                                         (__tmp48688
-                                                          (let ((__tmp48689
+                                                         (__tmp48663
+                                                          (let ((__tmp48664
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                         (let ((__tmp48690
-                                (let ((__tmp48694
+                         (let ((__tmp48665
+                                (let ((__tmp48669
                                        (gx#datum->syntax '#f 'error))
-                                      (__tmp48691
-                                       (let ((__tmp48692
-                                              (let ((__tmp48693
+                                      (__tmp48666
+                                       (let ((__tmp48667
+                                              (let ((__tmp48668
                                                      (lambda (_g3725637259_
                                                               _g3725737262_)
                                                        (let ()
@@ -6000,26 +6000,26 @@
                                                          (cons _g3725637259_
                                                                _g3725737262_)))))
                                                 (declare (not safe))
-                                                (foldr1 __tmp48693
+                                                (foldr1 __tmp48668
                                                         '()
                                                         _L37142_))))
                                          (declare (not safe))
                                          (cons '"No clause matching"
-                                               __tmp48692))))
+                                               __tmp48667))))
                                   (declare (not safe))
-                                  (cons __tmp48694 __tmp48691))))
+                                  (cons __tmp48669 __tmp48666))))
                            (declare (not safe))
-                           (cons __tmp48690 '()))))
+                           (cons __tmp48665 '()))))
                     (declare (not safe))
-                    (cons '() __tmp48689))))
+                    (cons '() __tmp48664))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (declare (not safe))
-                                                     (cons __tmp48695
-                                                           __tmp48688))
+                                                     (cons __tmp48670
+                                                           __tmp48663))
                                                    (gx#stx-source
                                                     _stx36347_))))
                                             (declare (not safe))
-                                            (_g3715837253_ __tmp48687))))
+                                            (_g3715837253_ __tmp48662))))
                                       _target3709937138_))))))
                      (let ()
                        (declare (not safe))
@@ -6035,9 +6035,9 @@
                                      (declare (not safe))
                                      (_g3708737265_ _tgt-lst36349_))))
                                _g3706237073_)))
-                           (__tmp48697 (gx#genident 'E)))
+                           (__tmp48672 (gx#genident 'E)))
                       (declare (not safe))
-                      (_g3706037269_ __tmp48697))))
+                      (_g3706037269_ __tmp48672))))
                  (_generate-clauses36355_
                   (lambda (_rest36710_ _E36712_)
                     (let* ((___stx4753647537_ _rest36710_)
@@ -6094,9 +6094,9 @@
                                 (##cdr _e3698937022_))))
                          (if (gx#stx-null? _tl3698737029_)
                              ((lambda (_L37032_ _L37034_)
-                                (let ((__tmp48698
-                                       (let ((__tmp48699
-                                              (let ((__tmp48700
+                                (let ((__tmp48673
+                                       (let ((__tmp48674
+                                              (let ((__tmp48675
                                                      (if (gx#stx-e _L37034_)
                                                          (let ()
                                                            (declare (not safe))
@@ -6106,11 +6106,11 @@
                                                             _E36712_))
                                                          _L37032_)))
                                                 (declare (not safe))
-                                                (cons __tmp48700 '()))))
+                                                (cons __tmp48675 '()))))
                                          (declare (not safe))
-                                         (cons '@match-body __tmp48699))))
+                                         (cons '@match-body __tmp48674))))
                                   (declare (not safe))
-                                  (cons 'begin-annotation __tmp48698)))
+                                  (cons 'begin-annotation __tmp48673)))
                               _hd3698837026_
                               _hd3698537016_)
                              (let ()
@@ -6214,38 +6214,38 @@
                       (if (gx#stx-null? _tl3685836890_)
                           ((lambda (_L36893_ _L36895_)
                              (let ()
-                               (let ((__tmp48727 (gx#datum->syntax '#f 'let))
-                                     (__tmp48718
-                                      (let ((__tmp48720
-                                             (let ((__tmp48721
-                                                    (let ((__tmp48722
-                                                           (let ((__tmp48723
+                               (let ((__tmp48702 (gx#datum->syntax '#f 'let))
+                                     (__tmp48693
+                                      (let ((__tmp48695
+                                             (let ((__tmp48696
+                                                    (let ((__tmp48697
+                                                           (let ((__tmp48698
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                          (let ((__tmp48726 (gx#datum->syntax '#f 'lambda))
-                                (__tmp48724
-                                 (let ((__tmp48725
+                          (let ((__tmp48701 (gx#datum->syntax '#f 'lambda))
+                                (__tmp48699
+                                 (let ((__tmp48700
                                         (let ()
                                           (declare (not safe))
                                           (cons _L36895_ '()))))
                                    (declare (not safe))
-                                   (cons '() __tmp48725))))
+                                   (cons '() __tmp48700))))
                             (declare (not safe))
-                            (cons __tmp48726 __tmp48724))))
+                            (cons __tmp48701 __tmp48699))))
                      (declare (not safe))
-                     (cons __tmp48723 '()))))
+                     (cons __tmp48698 '()))))
               (declare (not safe))
-              (cons _L36834_ __tmp48722))))
+              (cons _L36834_ __tmp48697))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                (declare (not safe))
-                                               (cons __tmp48721 '())))
-                                            (__tmp48719
+                                               (cons __tmp48696 '())))
+                                            (__tmp48694
                                              (let ()
                                                (declare (not safe))
                                                (cons _L36893_ '()))))
                                         (declare (not safe))
-                                        (cons __tmp48720 __tmp48719))))
+                                        (cons __tmp48695 __tmp48694))))
                                  (declare (not safe))
-                                 (cons __tmp48727 __tmp48718))))
+                                 (cons __tmp48702 __tmp48693))))
                            _hd3685936887_
                            _hd3685636877_)
                           (let ()
@@ -6259,14 +6259,14 @@
                                                     (declare (not safe))
                                                     (_g3685136866_
                                                      _g3685236870_)))))
-                                           (__tmp48728
+                                           (__tmp48703
                                             (list (let ()
                                                     (declare (not safe))
                                                     (_generate136356_
                                                      _L36833_
                                                      _L36831_
                                                      _E36712_))
-                                                  (let ((__tmp48729
+                                                  (let ((__tmp48704
                                                          (let ()
                                                            (declare (not safe))
                                                            (cons _L36834_
@@ -6276,9 +6276,9 @@
                                                     (declare (not safe))
                                                     (_generate-clauses36355_
                                                      _L36760_
-                                                     __tmp48729)))))
+                                                     __tmp48704)))))
                                       (declare (not safe))
-                                      (_g3685036911_ __tmp48728))
+                                      (_g3685036911_ __tmp48703))
                                     (let* ((_g3691536923_
                                             (lambda (_g3691636919_)
                                               (gx#raise-syntax-error
@@ -6289,71 +6289,71 @@
                                             (lambda (_g3691636927_)
                                               ((lambda (_L36930_)
                                                  (let ()
-                                                   (let ((__tmp48715
+                                                   (let ((__tmp48690
                                                           (gx#datum->syntax
                                                            '#f
                                                            'let))
-                                                         (__tmp48701
-                                                          (let ((__tmp48703
+                                                         (__tmp48676
+                                                          (let ((__tmp48678
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                         (let ((__tmp48704
-                                (let ((__tmp48705
-                                       (let ((__tmp48706
-                                              (let ((__tmp48714
+                         (let ((__tmp48679
+                                (let ((__tmp48680
+                                       (let ((__tmp48681
+                                              (let ((__tmp48689
                                                      (gx#datum->syntax
                                                       '#f
                                                       'begin-annotation))
-                                                    (__tmp48707
-                                                     (let ((__tmp48713
+                                                    (__tmp48682
+                                                     (let ((__tmp48688
                                                             (gx#datum->syntax
                                                              '#f
                                                              '@match-else))
-                                                           (__tmp48708
-                                                            (let ((__tmp48709
+                                                           (__tmp48683
+                                                            (let ((__tmp48684
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                           (let ((__tmp48712 (gx#datum->syntax '#f 'lambda))
-                                 (__tmp48710
-                                  (let ((__tmp48711
+                           (let ((__tmp48687 (gx#datum->syntax '#f 'lambda))
+                                 (__tmp48685
+                                  (let ((__tmp48686
                                          (let ()
                                            (declare (not safe))
                                            (cons _L36831_ '()))))
                                     (declare (not safe))
-                                    (cons '() __tmp48711))))
+                                    (cons '() __tmp48686))))
                              (declare (not safe))
-                             (cons __tmp48712 __tmp48710))))
+                             (cons __tmp48687 __tmp48685))))
                       (declare (not safe))
-                      (cons __tmp48709 '()))))
+                      (cons __tmp48684 '()))))
                (declare (not safe))
-               (cons __tmp48713 __tmp48708))))
+               (cons __tmp48688 __tmp48683))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                 (declare (not safe))
-                                                (cons __tmp48714 __tmp48707))))
+                                                (cons __tmp48689 __tmp48682))))
                                          (declare (not safe))
-                                         (cons __tmp48706 '()))))
+                                         (cons __tmp48681 '()))))
                                   (declare (not safe))
-                                  (cons _L36834_ __tmp48705))))
+                                  (cons _L36834_ __tmp48680))))
                            (declare (not safe))
-                           (cons __tmp48704 '())))
-                        (__tmp48702
+                           (cons __tmp48679 '())))
+                        (__tmp48677
                          (let () (declare (not safe)) (cons _L36930_ '()))))
                     (declare (not safe))
-                    (cons __tmp48703 __tmp48702))))
+                    (cons __tmp48678 __tmp48677))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (declare (not safe))
-                                                     (cons __tmp48715
-                                                           __tmp48701))))
+                                                     (cons __tmp48690
+                                                           __tmp48676))))
                                                _g3691636927_)))
-                                           (__tmp48716
-                                            (let ((__tmp48717
+                                           (__tmp48691
+                                            (let ((__tmp48692
                                                    (let ()
                                                      (declare (not safe))
                                                      (cons _L36834_ '()))))
                                               (declare (not safe))
                                               (_generate-clauses36355_
                                                _L36760_
-                                               __tmp48717))))
+                                               __tmp48692))))
                                       (declare (not safe))
-                                      (_g3691436941_ __tmp48716))))
+                                      (_g3691436941_ __tmp48691))))
                               _hd3678736825_
                               _hd3678436815_
                               _hd3678136805_)
@@ -6376,15 +6376,15 @@
                                  (_g3677436945_ _L36762_))))
                             (___kont4754347544_
                              (lambda ()
-                               (let ((__tmp48730
-                                      (let ((__tmp48731
+                               (let ((__tmp48705
+                                      (let ((__tmp48706
                                              (let ()
                                                (declare (not safe))
                                                (cons _E36712_ '()))))
                                         (declare (not safe))
-                                        (cons '@match-body __tmp48731))))
+                                        (cons '@match-body __tmp48706))))
                                  (declare (not safe))
-                                 (cons 'begin-annotation __tmp48730)))))
+                                 (cons 'begin-annotation __tmp48705)))))
                         (if (gx#stx-pair? ___stx4753647537_)
                             (let ((_e3672136956_
                                    (gx#syntax-e ___stx4753647537_)))
@@ -6436,25 +6436,25 @@
                                                      (##cdr _e3637236404_))))
                                               (if (gx#stx-pair/null?
                                                    _hd3637136408_)
-                                                  (let ((_g48732_
+                                                  (let ((_g48707_
                                                          (gx#syntax-split-splice
                                                           _hd3637136408_
                                                           '0)))
                                                     (begin
-                                                      (let ((_g48733_
+                                                      (let ((_g48708_
                                                              (let ()
                                                                (declare
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                          (not safe))
-                       (if (##values? _g48732_)
-                           (##vector-length _g48732_)
+                       (if (##values? _g48707_)
+                           (##vector-length _g48707_)
                            1))))
-                (if (not (let () (declare (not safe)) (##fx= _g48733_ 2)))
-                    (error "Context expects 2 values" _g48733_)))
+                (if (not (let () (declare (not safe)) (##fx= _g48708_ 2)))
+                    (error "Context expects 2 values" _g48708_)))
               (let ((_target3637336414_
-                     (let () (declare (not safe)) (##vector-ref _g48732_ 0)))
+                     (let () (declare (not safe)) (##vector-ref _g48707_ 0)))
                     (_tl3637536417_
-                     (let () (declare (not safe)) (##vector-ref _g48732_ 1))))
+                     (let () (declare (not safe)) (##vector-ref _g48707_ 1))))
                 (if (gx#stx-null? _tl3637536417_)
                     (letrec ((_loop3637636420_
                               (lambda (_hd3637436424_ _var3638036427_)
@@ -6469,7 +6469,7 @@
                                              (let ()
                                                (declare (not safe))
                                                (##cdr _e3637736430_))))
-                                        (let ((__tmp48750
+                                        (let ((__tmp48725
                                                (let ()
                                                  (declare (not safe))
                                                  (cons _lp-hd3637836434_
@@ -6477,14 +6477,14 @@
                                           (declare (not safe))
                                           (_loop3637636420_
                                            _lp-tl3637936437_
-                                           __tmp48750))))
+                                           __tmp48725))))
                                     (let ((_var3638136440_
                                            (reverse _var3638036427_)))
                                       (if (gx#stx-null? _tl3637036411_)
                                           ((lambda (_L36444_ _L36446_)
                                              (let ()
                                                (gx#check-duplicate-identifiers
-                                                (let ((__tmp48734
+                                                (let ((__tmp48709
                                                        (lambda (_g3646736470_
                                                                 _g3646836473_)
                                                          (let ()
@@ -6494,7 +6494,7 @@
                          _g3646836473_)))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                   (declare (not safe))
-                                                  (foldr1 __tmp48734
+                                                  (foldr1 __tmp48709
                                                           '()
                                                           _L36444_))
                                                 _stx36347_)
@@ -6531,61 +6531,61 @@
                                                   (let ()
                                                     (let ()
                                                       (gx#stx-wrap-source
-                                                       (let ((__tmp48739
+                                                       (let ((__tmp48714
                                                               (gx#datum->syntax
                                                                '#f
                                                                'let))
-                                                             (__tmp48735
-                                                              (let ((__tmp48737
+                                                             (__tmp48710
+                                                              (let ((__tmp48712
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                             (let ((__tmp48738
+                             (let ((__tmp48713
                                     (let ()
                                       (declare (not safe))
                                       (cons _L36547_ '()))))
                                (declare (not safe))
-                               (cons _L36446_ __tmp48738)))
-                            (__tmp48736
+                               (cons _L36446_ __tmp48713)))
+                            (__tmp48711
                              (let ()
                                (declare (not safe))
                                (cons _L36491_ '()))))
                         (declare (not safe))
-                        (cons __tmp48737 __tmp48736))))
+                        (cons __tmp48712 __tmp48711))))
                  (declare (not safe))
-                 (cons __tmp48739 __tmp48735))
+                 (cons __tmp48714 __tmp48710))
                (gx#stx-source _stx36347_)))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                 _g3653336544_)))
-                                            (__tmp48740
+                                            (__tmp48715
                                              (gx#stx-wrap-source
-                                              (let ((__tmp48745
+                                              (let ((__tmp48720
                                                      (gx#datum->syntax
                                                       '#f
                                                       'lambda))
-                                                    (__tmp48741
-                                                     (let ((__tmp48743
-                                                            (let ((__tmp48744
+                                                    (__tmp48716
+                                                     (let ((__tmp48718
+                                                            (let ((__tmp48719
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                            (lambda (_g3656536568_ _g3656636571_)
                              (let ()
                                (declare (not safe))
                                (cons _g3656536568_ _g3656636571_)))))
                       (declare (not safe))
-                      (foldr1 __tmp48744 '() _L36444_)))
-                   (__tmp48742
+                      (foldr1 __tmp48719 '() _L36444_)))
+                   (__tmp48717
                     (let () (declare (not safe)) (cons _L36519_ '()))))
                (declare (not safe))
-               (cons __tmp48743 __tmp48742))))
+               (cons __tmp48718 __tmp48717))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                 (declare (not safe))
-                                                (cons __tmp48745 __tmp48741))
+                                                (cons __tmp48720 __tmp48716))
                                               (gx#stx-source _stx36347_))))
                                        (declare (not safe))
-                                       (_g3653136562_ __tmp48740))))
+                                       (_g3653136562_ __tmp48715))))
                                  _g3650536516_))))
                         (declare (not safe))
                         (_g3650336574_ _body36360_))))
                   _g3647736488_)))
-              (__tmp48746
+              (__tmp48721
                (let _recur36582_ ((_rest36585_ _clause36358_)
                                   (_rest-targets36587_ _tgt-lst36349_))
                  (let* ((___stx4756247563_ _rest36585_)
@@ -6617,7 +6617,7 @@
                                                      (declare (not safe))
                                                      (##cdr _e3666136674_))))
                                               ((lambda (_L36684_ _L36686_)
-                                                 (let ((__tmp48747
+                                                 (let ((__tmp48722
                                                         (let ()
                                                           (declare (not safe))
                                                           (_recur36582_
@@ -6628,7 +6628,7 @@
                                                     _stx36347_
                                                     _L36686_
                                                     _L36640_
-                                                    __tmp48747
+                                                    __tmp48722
                                                     _E36361_)))
                                                _tl3665936681_
                                                _hd3666036678_)))
@@ -6639,17 +6639,17 @@
                               (_g3665436698_ _rest-targets36587_))))
                          (___kont4756747568_
                           (lambda ()
-                            (let ((__tmp48748
-                                   (let ((__tmp48749
+                            (let ((__tmp48723
+                                   (let ((__tmp48724
                                           (lambda (_g3661236615_ _g3661336618_)
                                             (let ()
                                               (declare (not safe))
                                               (cons _g3661236615_
                                                     _g3661336618_)))))
                                      (declare (not safe))
-                                     (foldr1 __tmp48749 '() _L36444_))))
+                                     (foldr1 __tmp48724 '() _L36444_))))
                               (declare (not safe))
-                              (cons _L36446_ __tmp48748)))))
+                              (cons _L36446_ __tmp48723)))))
                      (if (gx#stx-pair? ___stx4756247563_)
                          (let ((_e3659636628_ (gx#syntax-e ___stx4756247563_)))
                            (let ((_tl3659436635_
@@ -6666,7 +6666,7 @@
                          (___kont4756747568_)))))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                  (declare (not safe))
-                                                 (_g3647536578_ __tmp48746))))
+                                                 (_g3647536578_ __tmp48721))))
                                            _var3638136440_
                                            _hd3636836398_)
                                           (let ()
@@ -6690,19 +6690,19 @@
                                   (let ()
                                     (declare (not safe))
                                     (_g3636336387_ _g3636436391_)))))
-                           (__tmp48751
+                           (__tmp48726
                             (list (gx#genident 'K)
                                   (apply append
                                          (map |gerbil/core/match[1]#match-pattern-vars|
                                               _clause36358_)))))
                       (declare (not safe))
-                      (_g3636236706_ __tmp48751)))))
-          (let ((__tmp48752
-                 (let ((__tmp48753 (gx#stx-length _tgt-lst36349_)))
+                      (_g3636236706_ __tmp48726)))))
+          (let ((__tmp48727
+                 (let ((__tmp48728 (gx#stx-length _tgt-lst36349_)))
                    (declare (not safe))
-                   (_parse-body36352_ __tmp48753))))
+                   (_parse-body36352_ __tmp48728))))
             (declare (not safe))
-            (_generate-body36354_ __tmp48752)))))
+            (_generate-body36354_ __tmp48727)))))
     (define |gerbil/core/match[1]#generate-match|
       (lambda (_stx36249_ _tgt36251_ _clauses36252_)
         (letrec ((_reclause36254_
@@ -6718,12 +6718,12 @@
                             (___kont4758347584_
                              (lambda (_L36305_ _L36307_)
                                (gx#stx-wrap-source
-                                (let ((__tmp48754
+                                (let ((__tmp48729
                                        (let ()
                                          (declare (not safe))
                                          (cons _L36307_ '()))))
                                   (declare (not safe))
-                                  (cons __tmp48754 _L36305_))
+                                  (cons __tmp48729 _L36305_))
                                 (gx#stx-source
                                  (gx#datum->syntax '#f 'clause)))))
                             (___kont4758547586_
@@ -6746,7 +6746,7 @@
                                        (##car _e3626636329_))))
                                 (if (gx#identifier? _hd3626536333_)
                                     (if (gx#free-identifier=?
-                                         |gerbil/core/match[1]#_g48755_|
+                                         |gerbil/core/match[1]#_g48730_|
                                          _hd3626536333_)
                                         (___kont4758147582_)
                                         (___kont4758347584_
@@ -6756,14 +6756,14 @@
                                      _tl3626436336_
                                      _hd3626536333_))))
                             (___kont4758547586_)))))))
-          (let ((__tmp48757
+          (let ((__tmp48732
                  (let () (declare (not safe)) (cons _tgt36251_ '())))
-                (__tmp48756 (gx#stx-map _reclause36254_ _clauses36252_)))
+                (__tmp48731 (gx#stx-map _reclause36254_ _clauses36252_)))
             (declare (not safe))
             (|gerbil/core/match[1]#generate-match*|
              _stx36249_
-             __tmp48757
-             __tmp48756)))))
+             __tmp48732
+             __tmp48731)))))
     (define |gerbil/core/match[:0:]#match|
       (lambda (_stx43479_)
         (let* ((___stx4760647607_ _stx43479_)
@@ -6796,33 +6796,33 @@
                                             ((lambda (_L43808_)
                                                (let ()
                                                  (let ()
-                                                   (let ((__tmp48761
+                                                   (let ((__tmp48736
                                                           (gx#datum->syntax
                                                            '#f
                                                            'lambda))
-                                                         (__tmp48758
-                                                          (let ((__tmp48760
+                                                         (__tmp48733
+                                                          (let ((__tmp48735
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                          (let () (declare (not safe)) (cons _L43781_ '())))
-                        (__tmp48759
+                        (__tmp48734
                          (let () (declare (not safe)) (cons _L43808_ '()))))
                     (declare (not safe))
-                    (cons __tmp48760 __tmp48759))))
+                    (cons __tmp48735 __tmp48734))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (declare (not safe))
-                                                     (cons __tmp48761
-                                                           __tmp48758)))))
+                                                     (cons __tmp48736
+                                                           __tmp48733)))))
                                              _g4379443805_))))
                                     (_g4379243823_
                                      (gx#stx-wrap-source
-                                      (let ((__tmp48763
+                                      (let ((__tmp48738
                                              (gx#datum->syntax '#f 'match))
-                                            (__tmp48762
+                                            (__tmp48737
                                              (let ()
                                                (declare (not safe))
                                                (cons _L43781_ _L43753_))))
                                         (declare (not safe))
-                                        (cons __tmp48763 __tmp48762))
+                                        (cons __tmp48738 __tmp48737))
                                       (gx#stx-source _stx43479_))))))
                               _g4376743778_))))
                      (_g4376543827_ (gx#genident 'e)))))
@@ -6849,31 +6849,31 @@
                                             ((lambda (_L43703_)
                                                (let ()
                                                  (let ()
-                                                   (let ((__tmp48766
+                                                   (let ((__tmp48741
                                                           (gx#datum->syntax
                                                            '#f
                                                            'lambda))
-                                                         (__tmp48764
-                                                          (let ((__tmp48765
+                                                         (__tmp48739
+                                                          (let ((__tmp48740
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                          (let () (declare (not safe)) (cons _L43703_ '()))))
                     (declare (not safe))
-                    (cons _L43676_ __tmp48765))))
+                    (cons _L43676_ __tmp48740))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (declare (not safe))
-                                                     (cons __tmp48766
-                                                           __tmp48764)))))
+                                                     (cons __tmp48741
+                                                           __tmp48739)))))
                                              _g4368943700_))))
                                     (_g4368743718_
                                      (gx#stx-wrap-source
-                                      (let ((__tmp48768
+                                      (let ((__tmp48743
                                              (gx#datum->syntax '#f 'match))
-                                            (__tmp48767
+                                            (__tmp48742
                                              (let ()
                                                (declare (not safe))
                                                (cons _L43676_ _L43648_))))
                                         (declare (not safe))
-                                        (cons __tmp48768 __tmp48767))
+                                        (cons __tmp48743 __tmp48742))
                                       (gx#stx-source _stx43479_))))))
                               _g4366243673_))))
                      (_g4366043722_ (gx#genident 'args)))))
@@ -6900,30 +6900,30 @@
                                             ((lambda (_L43598_)
                                                (let ()
                                                  (let ()
-                                                   (let ((__tmp48774
+                                                   (let ((__tmp48749
                                                           (gx#datum->syntax
                                                            '#f
                                                            'let))
-                                                         (__tmp48769
-                                                          (let ((__tmp48771
+                                                         (__tmp48744
+                                                          (let ((__tmp48746
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                         (let ((__tmp48772
-                                (let ((__tmp48773
+                         (let ((__tmp48747
+                                (let ((__tmp48748
                                        (let ()
                                          (declare (not safe))
                                          (cons _L43542_ '()))))
                                   (declare (not safe))
-                                  (cons _L43571_ __tmp48773))))
+                                  (cons _L43571_ __tmp48748))))
                            (declare (not safe))
-                           (cons __tmp48772 '())))
-                        (__tmp48770
+                           (cons __tmp48747 '())))
+                        (__tmp48745
                          (let () (declare (not safe)) (cons _L43598_ '()))))
                     (declare (not safe))
-                    (cons __tmp48771 __tmp48770))))
+                    (cons __tmp48746 __tmp48745))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (declare (not safe))
-                                                     (cons __tmp48774
-                                                           __tmp48769)))))
+                                                     (cons __tmp48749
+                                                           __tmp48744)))))
                                              _g4358443595_))))
                                     (_g4358243613_
                                      (let ()
@@ -7000,7 +7000,7 @@
                                      (##car _e4349243743_))))
                               (if (gx#identifier? _hd4349143747_)
                                   (if (gx#free-identifier=?
-                                       |gerbil/core/match[1]#_g48776_|
+                                       |gerbil/core/match[1]#_g48751_|
                                        _hd4349143747_)
                                       (___match4763147632_
                                        _e4348943733_
@@ -7010,7 +7010,7 @@
                                        _hd4349143747_
                                        _tl4349043750_)
                                       (if (gx#free-identifier=?
-                                           |gerbil/core/match[1]#_g48775_|
+                                           |gerbil/core/match[1]#_g48750_|
                                            _hd4349143747_)
                                           (___match4764747648_
                                            _e4348943733_
@@ -7067,31 +7067,31 @@
                                          (declare (not safe))
                                          (##cdr _e4384743879_))))
                                   (if (gx#stx-pair/null? _hd4384643883_)
-                                      (let ((_g48777_
+                                      (let ((_g48752_
                                              (gx#syntax-split-splice
                                               _hd4384643883_
                                               '0)))
                                         (begin
-                                          (let ((_g48778_
+                                          (let ((_g48753_
                                                  (let ()
                                                    (declare (not safe))
-                                                   (if (##values? _g48777_)
+                                                   (if (##values? _g48752_)
                                                        (##vector-length
-                                                        _g48777_)
+                                                        _g48752_)
                                                        1))))
                                             (if (not (let ()
                                                        (declare (not safe))
-                                                       (##fx= _g48778_ 2)))
+                                                       (##fx= _g48753_ 2)))
                                                 (error "Context expects 2 values"
-                                                       _g48778_)))
+                                                       _g48753_)))
                                           (let ((_target4384843889_
                                                  (let ()
                                                    (declare (not safe))
-                                                   (##vector-ref _g48777_ 0)))
+                                                   (##vector-ref _g48752_ 0)))
                                                 (_tl4385043892_
                                                  (let ()
                                                    (declare (not safe))
-                                                   (##vector-ref _g48777_ 1))))
+                                                   (##vector-ref _g48752_ 1))))
                                             (if (gx#stx-null? _tl4385043892_)
                                                 (letrec ((_loop4385143895_
                                                           (lambda (_hd4384943899_
@@ -7125,41 +7125,41 @@
                                          (lambda (_g4394043960_)
                                            (if (gx#stx-pair/null?
                                                 _g4394043960_)
-                                               (let ((_g48779_
+                                               (let ((_g48754_
                                                       (gx#syntax-split-splice
                                                        _g4394043960_
                                                        '0)))
                                                  (begin
-                                                   (let ((_g48780_
+                                                   (let ((_g48755_
                                                           (let ()
                                                             (declare
                                                               (not safe))
                                                             (if (##values?
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                         _g48779_)
-                        (##vector-length _g48779_)
+                         _g48754_)
+                        (##vector-length _g48754_)
                         1))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (if (not (let ()
                                                                 (declare
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                           (not safe))
-                        (##fx= _g48780_ 2)))
-                 (error "Context expects 2 values" _g48780_)))
+                        (##fx= _g48755_ 2)))
+                 (error "Context expects 2 values" _g48755_)))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                    (let ((_target4394243963_
                                                           (let ()
                                                             (declare
                                                               (not safe))
                                                             (##vector-ref
-                                                             _g48779_
+                                                             _g48754_
                                                              0)))
                                                          (_tl4394443966_
                                                           (let ()
                                                             (declare
                                                               (not safe))
                                                             (##vector-ref
-                                                             _g48779_
+                                                             _g48754_
                                                              1))))
                                                      (if (gx#stx-null?
                                                           _tl4394443966_)
@@ -7198,47 +7198,47 @@
                                                   ((lambda (_L44024_)
                                                      (let ()
                                                        (let ()
-                                                         (let ((__tmp48787
+                                                         (let ((__tmp48762
                                                                 (gx#datum->syntax
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                          '#f
                          'let))
-                       (__tmp48781
-                        (let ((__tmp48783
+                       (__tmp48756
+                        (let ((__tmp48758
                                (begin
                                  (gx#syntax-check-splice-targets
                                   _L43921_
                                   _L43993_)
-                                 (let ((__tmp48784
+                                 (let ((__tmp48759
                                         (lambda (_g4403844042_
                                                  _g4403944045_
                                                  _g4404044047_)
-                                          (let ((__tmp48785
-                                                 (let ((__tmp48786
+                                          (let ((__tmp48760
+                                                 (let ((__tmp48761
                                                         (let ()
                                                           (declare (not safe))
                                                           (cons _g4403844042_
                                                                 '()))))
                                                    (declare (not safe))
                                                    (cons _g4403944045_
-                                                         __tmp48786))))
+                                                         __tmp48761))))
                                             (declare (not safe))
-                                            (cons __tmp48785 _g4404044047_)))))
+                                            (cons __tmp48760 _g4404044047_)))))
                                    (declare (not safe))
-                                   (foldr2 __tmp48784 '() _L43921_ _L43993_))))
-                              (__tmp48782
+                                   (foldr2 __tmp48759 '() _L43921_ _L43993_))))
+                              (__tmp48757
                                (let ()
                                  (declare (not safe))
                                  (cons _L44024_ '()))))
                           (declare (not safe))
-                          (cons __tmp48783 __tmp48782))))
+                          (cons __tmp48758 __tmp48757))))
                    (declare (not safe))
-                   (cons __tmp48787 __tmp48781)))))
+                   (cons __tmp48762 __tmp48756)))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                    _g4401044021_))))
                                           (_g4400844050_
-                                           (let ((__tmp48788
-                                                  (let ((__tmp48789
+                                           (let ((__tmp48763
+                                                  (let ((__tmp48764
                                                          (lambda (_g4405344056_
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                           _g4405444059_)
@@ -7247,13 +7247,13 @@
                      (cons _g4405344056_ _g4405444059_)))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                     (declare (not safe))
-                                                    (foldr1 __tmp48789
+                                                    (foldr1 __tmp48764
                                                             '()
                                                             _L43993_))))
                                              (declare (not safe))
                                              (|gerbil/core/match[1]#generate-match*|
                                               _stx43835_
-                                              __tmp48788
+                                              __tmp48763
                                               _L43919_))))))
                                     _$e4395043989_))))))
                    (_loop4394543969_ _target4394243963_ '()))
@@ -7263,7 +7263,7 @@
                                                 _g4394043960_)))))
                                    (_g4393844062_
                                     (gx#gentemps
-                                     (let ((__tmp48790
+                                     (let ((__tmp48765
                                             (lambda (_g4406544068_
                                                      _g4406644071_)
                                               (let ()
@@ -7271,7 +7271,7 @@
                                                 (cons _g4406544068_
                                                       _g4406644071_)))))
                                        (declare (not safe))
-                                       (foldr1 __tmp48790 '() _L43921_)))))
+                                       (foldr1 __tmp48765 '() _L43921_)))))
                                  (_g4383843862_ _g4383943866_)))
                            _tl4384543886_
                            _e4385643915_))))))
@@ -7296,64 +7296,64 @@
                    ___stx4766247663_))))
           (let ((___kont4766547666_
                  (lambda (_L44499_)
-                   (let ((__tmp48794 (gx#datum->syntax '#f 'let))
-                         (__tmp48791
-                          (let ((__tmp48792
-                                 (let ((__tmp48793
+                   (let ((__tmp48769 (gx#datum->syntax '#f 'let))
+                         (__tmp48766
+                          (let ((__tmp48767
+                                 (let ((__tmp48768
                                         (lambda (_g4451544518_ _g4451644521_)
                                           (let ()
                                             (declare (not safe))
                                             (cons _g4451544518_
                                                   _g4451644521_)))))
                                    (declare (not safe))
-                                   (foldr1 __tmp48793 '() _L44499_))))
+                                   (foldr1 __tmp48768 '() _L44499_))))
                             (declare (not safe))
-                            (cons '() __tmp48792))))
+                            (cons '() __tmp48767))))
                      (declare (not safe))
-                     (cons __tmp48794 __tmp48791))))
+                     (cons __tmp48769 __tmp48766))))
                 (___kont4766947670_
                  (lambda (_L44407_ _L44409_ _L44410_ _L44411_)
-                   (let ((__tmp48795
-                          (let ((__tmp48798
-                                 (let ((__tmp48799
-                                        (let ((__tmp48800
+                   (let ((__tmp48770
+                          (let ((__tmp48773
+                                 (let ((__tmp48774
+                                        (let ((__tmp48775
                                                (let ()
                                                  (declare (not safe))
                                                  (cons _L44409_ '()))))
                                           (declare (not safe))
-                                          (cons _L44410_ __tmp48800))))
+                                          (cons _L44410_ __tmp48775))))
                                    (declare (not safe))
-                                   (cons __tmp48799 '())))
-                                (__tmp48796
-                                 (let ((__tmp48797
+                                   (cons __tmp48774 '())))
+                                (__tmp48771
+                                 (let ((__tmp48772
                                         (lambda (_g4443344436_ _g4443444439_)
                                           (let ()
                                             (declare (not safe))
                                             (cons _g4443344436_
                                                   _g4443444439_)))))
                                    (declare (not safe))
-                                   (foldr1 __tmp48797 '() _L44407_))))
+                                   (foldr1 __tmp48772 '() _L44407_))))
                             (declare (not safe))
-                            (cons __tmp48798 __tmp48796))))
+                            (cons __tmp48773 __tmp48771))))
                      (declare (not safe))
-                     (cons _L44411_ __tmp48795))))
+                     (cons _L44411_ __tmp48770))))
                 (___kont4767347674_
                  (lambda (_L44280_ _L44282_ _L44283_)
-                   (let ((__tmp48810 (gx#datum->syntax '#f 'match*))
-                         (__tmp48801
-                          (let ((__tmp48808
-                                 (let ((__tmp48809
+                   (let ((__tmp48785 (gx#datum->syntax '#f 'match*))
+                         (__tmp48776
+                          (let ((__tmp48783
+                                 (let ((__tmp48784
                                         (lambda (_g4430944312_ _g4431044315_)
                                           (let ()
                                             (declare (not safe))
                                             (cons _g4430944312_
                                                   _g4431044315_)))))
                                    (declare (not safe))
-                                   (foldr1 __tmp48809 '() _L44282_)))
-                                (__tmp48802
-                                 (let ((__tmp48803
-                                        (let ((__tmp48806
-                                               (let ((__tmp48807
+                                   (foldr1 __tmp48784 '() _L44282_)))
+                                (__tmp48777
+                                 (let ((__tmp48778
+                                        (let ((__tmp48781
+                                               (let ((__tmp48782
                                                       (lambda (_g4430744318_
                                                                _g4430844321_)
                                                         (let ()
@@ -7361,11 +7361,11 @@
                                                           (cons _g4430744318_
                                                                 _g4430844321_)))))
                                                  (declare (not safe))
-                                                 (foldr1 __tmp48807
+                                                 (foldr1 __tmp48782
                                                          '()
                                                          _L44283_)))
-                                              (__tmp48804
-                                               (let ((__tmp48805
+                                              (__tmp48779
+                                               (let ((__tmp48780
                                                       (lambda (_g4430544324_
                                                                _g4430644327_)
                                                         (let ()
@@ -7373,17 +7373,17 @@
                                                           (cons _g4430544324_
                                                                 _g4430644327_)))))
                                                  (declare (not safe))
-                                                 (foldr1 __tmp48805
+                                                 (foldr1 __tmp48780
                                                          '()
                                                          _L44280_))))
                                           (declare (not safe))
-                                          (cons __tmp48806 __tmp48804))))
+                                          (cons __tmp48781 __tmp48779))))
                                    (declare (not safe))
-                                   (cons __tmp48803 '()))))
+                                   (cons __tmp48778 '()))))
                             (declare (not safe))
-                            (cons __tmp48808 __tmp48802))))
+                            (cons __tmp48783 __tmp48777))))
                      (declare (not safe))
-                     (cons __tmp48810 __tmp48801)))))
+                     (cons __tmp48785 __tmp48776)))))
             (let* ((___match4775547756_
                     (lambda (_e4413444176_
                              _hd4413344180_
@@ -7973,23 +7973,23 @@
                    ___stx4775847759_))))
           (let ((___kont4776147762_
                  (lambda (_L44759_ _L44761_ _L44762_ _L44763_ _L44764_)
-                   (let ((__tmp48820 (gx#datum->syntax '#f 'with))
-                         (__tmp48811
-                          (let ((__tmp48817
-                                 (let ((__tmp48818
-                                        (let ((__tmp48819
+                   (let ((__tmp48795 (gx#datum->syntax '#f 'with))
+                         (__tmp48786
+                          (let ((__tmp48792
+                                 (let ((__tmp48793
+                                        (let ((__tmp48794
                                                (let ()
                                                  (declare (not safe))
                                                  (cons _L44762_ '()))))
                                           (declare (not safe))
-                                          (cons _L44763_ __tmp48819))))
+                                          (cons _L44763_ __tmp48794))))
                                    (declare (not safe))
-                                   (cons __tmp48818 '())))
-                                (__tmp48812
-                                 (let ((__tmp48813
-                                        (let ((__tmp48814
-                                               (let ((__tmp48815
-                                                      (let ((__tmp48816
+                                   (cons __tmp48793 '())))
+                                (__tmp48787
+                                 (let ((__tmp48788
+                                        (let ((__tmp48789
+                                               (let ((__tmp48790
+                                                      (let ((__tmp48791
                                                              (lambda (_g4478944792_
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                               _g4479044795_)
@@ -7997,35 +7997,35 @@
                          (declare (not safe))
                          (cons _g4478944792_ _g4479044795_)))))
                 (declare (not safe))
-                (foldr1 __tmp48816 '() _L44759_))))
+                (foldr1 __tmp48791 '() _L44759_))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                  (declare (not safe))
-                                                 (cons _L44761_ __tmp48815))))
+                                                 (cons _L44761_ __tmp48790))))
                                           (declare (not safe))
-                                          (cons _L44764_ __tmp48814))))
+                                          (cons _L44764_ __tmp48789))))
                                    (declare (not safe))
-                                   (cons __tmp48813 '()))))
+                                   (cons __tmp48788 '()))))
                             (declare (not safe))
-                            (cons __tmp48817 __tmp48812))))
+                            (cons __tmp48792 __tmp48787))))
                      (declare (not safe))
-                     (cons __tmp48820 __tmp48811))))
+                     (cons __tmp48795 __tmp48786))))
                 (___kont4776547766_
                  (lambda (_L44646_)
-                   (let ((__tmp48824 (gx#datum->syntax '#f 'let))
-                         (__tmp48821
-                          (let ((__tmp48822
-                                 (let ((__tmp48823
+                   (let ((__tmp48799 (gx#datum->syntax '#f 'let))
+                         (__tmp48796
+                          (let ((__tmp48797
+                                 (let ((__tmp48798
                                         (lambda (_g4466344666_ _g4466444669_)
                                           (let ()
                                             (declare (not safe))
                                             (cons _g4466344666_
                                                   _g4466444669_)))))
                                    (declare (not safe))
-                                   (foldr1 __tmp48823 '() _L44646_))))
+                                   (foldr1 __tmp48798 '() _L44646_))))
                             (declare (not safe))
-                            (cons '() __tmp48822))))
+                            (cons '() __tmp48797))))
                      (declare (not safe))
-                     (cons __tmp48824 __tmp48821)))))
+                     (cons __tmp48799 __tmp48796)))))
             (let* ((___match4783147832_
                     (lambda (_e4457144596_
                              _hd4457044600_
@@ -8257,271 +8257,271 @@
                    ___stx4783447835_))))
           (let ((___kont4783747838_
                  (lambda (_L45565_ _L45567_ _L45568_)
-                   (let ((__tmp48830 (gx#datum->syntax '#f 'and))
-                         (__tmp48825
-                          (let ((__tmp48826
+                   (let ((__tmp48805 (gx#datum->syntax '#f 'and))
+                         (__tmp48800
+                          (let ((__tmp48801
                                  (lambda (_g4558945592_ _g4559045595_)
-                                   (let ((__tmp48827
-                                          (let ((__tmp48828
-                                                 (let ((__tmp48829
+                                   (let ((__tmp48802
+                                          (let ((__tmp48803
+                                                 (let ((__tmp48804
                                                         (let ()
                                                           (declare (not safe))
                                                           (cons _L45565_
                                                                 '()))))
                                                    (declare (not safe))
                                                    (cons _g4558945592_
-                                                         __tmp48829))))
+                                                         __tmp48804))))
                                             (declare (not safe))
-                                            (cons _L45568_ __tmp48828))))
+                                            (cons _L45568_ __tmp48803))))
                                      (declare (not safe))
-                                     (cons __tmp48827 _g4559045595_)))))
+                                     (cons __tmp48802 _g4559045595_)))))
                             (declare (not safe))
-                            (foldr1 __tmp48826 '() _L45567_))))
+                            (foldr1 __tmp48801 '() _L45567_))))
                      (declare (not safe))
-                     (cons __tmp48830 __tmp48825))))
+                     (cons __tmp48805 __tmp48800))))
                 (___kont4784147842_
                  (lambda (_L45455_ _L45457_ _L45458_)
-                   (let ((__tmp48836 (gx#datum->syntax '#f 'or))
-                         (__tmp48831
-                          (let ((__tmp48832
+                   (let ((__tmp48811 (gx#datum->syntax '#f 'or))
+                         (__tmp48806
+                          (let ((__tmp48807
                                  (lambda (_g4547945482_ _g4548045485_)
-                                   (let ((__tmp48833
-                                          (let ((__tmp48834
-                                                 (let ((__tmp48835
+                                   (let ((__tmp48808
+                                          (let ((__tmp48809
+                                                 (let ((__tmp48810
                                                         (let ()
                                                           (declare (not safe))
                                                           (cons _L45455_
                                                                 '()))))
                                                    (declare (not safe))
                                                    (cons _g4547945482_
-                                                         __tmp48835))))
+                                                         __tmp48810))))
                                             (declare (not safe))
-                                            (cons _L45458_ __tmp48834))))
+                                            (cons _L45458_ __tmp48809))))
                                      (declare (not safe))
-                                     (cons __tmp48833 _g4548045485_)))))
+                                     (cons __tmp48808 _g4548045485_)))))
                             (declare (not safe))
-                            (foldr1 __tmp48832 '() _L45457_))))
+                            (foldr1 __tmp48807 '() _L45457_))))
                      (declare (not safe))
-                     (cons __tmp48836 __tmp48831))))
+                     (cons __tmp48811 __tmp48806))))
                 (___kont4784547846_
                  (lambda (_L45355_ _L45357_ _L45358_)
-                   (let ((__tmp48841 (gx#datum->syntax '#f 'not))
-                         (__tmp48837
-                          (let ((__tmp48838
-                                 (let ((__tmp48839
-                                        (let ((__tmp48840
+                   (let ((__tmp48816 (gx#datum->syntax '#f 'not))
+                         (__tmp48812
+                          (let ((__tmp48813
+                                 (let ((__tmp48814
+                                        (let ((__tmp48815
                                                (let ()
                                                  (declare (not safe))
                                                  (cons _L45355_ '()))))
                                           (declare (not safe))
-                                          (cons _L45357_ __tmp48840))))
+                                          (cons _L45357_ __tmp48815))))
                                    (declare (not safe))
-                                   (cons _L45358_ __tmp48839))))
+                                   (cons _L45358_ __tmp48814))))
                             (declare (not safe))
-                            (cons __tmp48838 '()))))
+                            (cons __tmp48813 '()))))
                      (declare (not safe))
-                     (cons __tmp48841 __tmp48837))))
+                     (cons __tmp48816 __tmp48812))))
                 (___kont4784747848_
                  (lambda (_L45281_ _L45283_)
-                   (let ((__tmp48842
+                   (let ((__tmp48817
                           (let () (declare (not safe)) (cons _L45281_ '()))))
                      (declare (not safe))
-                     (cons _L45283_ __tmp48842))))
+                     (cons _L45283_ __tmp48817))))
                 (___kont4784947850_
                  (lambda (_L45229_ _L45231_)
-                   (let ((__tmp48851 (gx#datum->syntax '#f 'lambda))
-                         (__tmp48843
-                          (let ((__tmp48849
-                                 (let ((__tmp48850
+                   (let ((__tmp48826 (gx#datum->syntax '#f 'lambda))
+                         (__tmp48818
+                          (let ((__tmp48824
+                                 (let ((__tmp48825
                                         (gx#datum->syntax '#f '$obj)))
                                    (declare (not safe))
-                                   (cons __tmp48850 '())))
-                                (__tmp48844
-                                 (let ((__tmp48845
-                                        (let ((__tmp48846
-                                               (let ((__tmp48847
-                                                      (let ((__tmp48848
+                                   (cons __tmp48825 '())))
+                                (__tmp48819
+                                 (let ((__tmp48820
+                                        (let ((__tmp48821
+                                               (let ((__tmp48822
+                                                      (let ((__tmp48823
                                                              (gx#datum->syntax
                                                               '#f
                                                               '$obj)))
                                                         (declare (not safe))
-                                                        (cons __tmp48848
+                                                        (cons __tmp48823
                                                               '()))))
                                                  (declare (not safe))
-                                                 (cons _L45229_ __tmp48847))))
+                                                 (cons _L45229_ __tmp48822))))
                                           (declare (not safe))
-                                          (cons _L45231_ __tmp48846))))
+                                          (cons _L45231_ __tmp48821))))
                                    (declare (not safe))
-                                   (cons __tmp48845 '()))))
+                                   (cons __tmp48820 '()))))
                             (declare (not safe))
-                            (cons __tmp48849 __tmp48844))))
+                            (cons __tmp48824 __tmp48819))))
                      (declare (not safe))
-                     (cons __tmp48851 __tmp48843))))
+                     (cons __tmp48826 __tmp48818))))
                 (___kont4785147852_
                  (lambda (_L45181_ _L45183_ _L45184_)
-                   (let ((__tmp48870 (gx#datum->syntax '#f 'lambda))
-                         (__tmp48852
-                          (let ((__tmp48868
-                                 (let ((__tmp48869
+                   (let ((__tmp48845 (gx#datum->syntax '#f 'lambda))
+                         (__tmp48827
+                          (let ((__tmp48843
+                                 (let ((__tmp48844
                                         (gx#datum->syntax '#f '$obj)))
                                    (declare (not safe))
-                                   (cons __tmp48869 '())))
-                                (__tmp48853
-                                 (let ((__tmp48854
-                                        (let ((__tmp48867
+                                   (cons __tmp48844 '())))
+                                (__tmp48828
+                                 (let ((__tmp48829
+                                        (let ((__tmp48842
                                                (gx#datum->syntax '#f 'alet))
-                                              (__tmp48855
-                                               (let ((__tmp48860
-                                                      (let ((__tmp48866
+                                              (__tmp48830
+                                               (let ((__tmp48835
+                                                      (let ((__tmp48841
                                                              (gx#datum->syntax
                                                               '#f
                                                               '$val))
-                                                            (__tmp48861
-                                                             (let ((__tmp48862
+                                                            (__tmp48836
+                                                             (let ((__tmp48837
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                            (let ((__tmp48863
-                                   (let ((__tmp48864
-                                          (let ((__tmp48865
+                            (let ((__tmp48838
+                                   (let ((__tmp48839
+                                          (let ((__tmp48840
                                                  (gx#datum->syntax '#f '$obj)))
                                             (declare (not safe))
-                                            (cons __tmp48865 '()))))
+                                            (cons __tmp48840 '()))))
                                      (declare (not safe))
-                                     (cons _L45183_ __tmp48864))))
+                                     (cons _L45183_ __tmp48839))))
                               (declare (not safe))
-                              (cons _L45184_ __tmp48863))))
+                              (cons _L45184_ __tmp48838))))
                        (declare (not safe))
-                       (cons __tmp48862 '()))))
+                       (cons __tmp48837 '()))))
                 (declare (not safe))
-                (cons __tmp48866 __tmp48861)))
+                (cons __tmp48841 __tmp48836)))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-                                                     (__tmp48856
-                                                      (let ((__tmp48857
-                                                             (let ((__tmp48858
+                                                     (__tmp48831
+                                                      (let ((__tmp48832
+                                                             (let ((__tmp48833
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                            (let ((__tmp48859 (gx#datum->syntax '#f '$val)))
+                            (let ((__tmp48834 (gx#datum->syntax '#f '$val)))
                               (declare (not safe))
-                              (cons __tmp48859 '()))))
+                              (cons __tmp48834 '()))))
                        (declare (not safe))
-                       (cons _L45181_ __tmp48858))))
+                       (cons _L45181_ __tmp48833))))
                 (declare (not safe))
-                (cons __tmp48857 '()))))
+                (cons __tmp48832 '()))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                  (declare (not safe))
-                                                 (cons __tmp48860
-                                                       __tmp48856))))
+                                                 (cons __tmp48835
+                                                       __tmp48831))))
                                           (declare (not safe))
-                                          (cons __tmp48867 __tmp48855))))
+                                          (cons __tmp48842 __tmp48830))))
                                    (declare (not safe))
-                                   (cons __tmp48854 '()))))
+                                   (cons __tmp48829 '()))))
                             (declare (not safe))
-                            (cons __tmp48868 __tmp48853))))
+                            (cons __tmp48843 __tmp48828))))
                      (declare (not safe))
-                     (cons __tmp48870 __tmp48852))))
+                     (cons __tmp48845 __tmp48827))))
                 (___kont4785347854_
                  (lambda (_L45112_ _L45114_ _L45115_)
-                   (let ((__tmp48886 (gx#datum->syntax '#f 'lambda))
-                         (__tmp48871
-                          (let ((__tmp48884
-                                 (let ((__tmp48885
+                   (let ((__tmp48861 (gx#datum->syntax '#f 'lambda))
+                         (__tmp48846
+                          (let ((__tmp48859
+                                 (let ((__tmp48860
                                         (gx#datum->syntax '#f '$obj)))
                                    (declare (not safe))
-                                   (cons __tmp48885 '())))
-                                (__tmp48872
-                                 (let ((__tmp48873
-                                        (let ((__tmp48883
+                                   (cons __tmp48860 '())))
+                                (__tmp48847
+                                 (let ((__tmp48848
+                                        (let ((__tmp48858
                                                (gx#datum->syntax '#f 'and))
-                                              (__tmp48874
-                                               (let ((__tmp48879
-                                                      (let ((__tmp48880
-                                                             (let ((__tmp48881
+                                              (__tmp48849
+                                               (let ((__tmp48854
+                                                      (let ((__tmp48855
+                                                             (let ((__tmp48856
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                            (let ((__tmp48882 (gx#datum->syntax '#f '$obj)))
+                            (let ((__tmp48857 (gx#datum->syntax '#f '$obj)))
                               (declare (not safe))
-                              (cons __tmp48882 '()))))
+                              (cons __tmp48857 '()))))
                        (declare (not safe))
-                       (cons _L45114_ __tmp48881))))
+                       (cons _L45114_ __tmp48856))))
                 (declare (not safe))
-                (cons _L45115_ __tmp48880)))
+                (cons _L45115_ __tmp48855)))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-                                                     (__tmp48875
-                                                      (let ((__tmp48876
-                                                             (let ((__tmp48877
+                                                     (__tmp48850
+                                                      (let ((__tmp48851
+                                                             (let ((__tmp48852
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                            (let ((__tmp48878 (gx#datum->syntax '#f '$obj)))
+                            (let ((__tmp48853 (gx#datum->syntax '#f '$obj)))
                               (declare (not safe))
-                              (cons __tmp48878 '()))))
+                              (cons __tmp48853 '()))))
                        (declare (not safe))
-                       (cons _L45112_ __tmp48877))))
+                       (cons _L45112_ __tmp48852))))
                 (declare (not safe))
-                (cons __tmp48876 '()))))
+                (cons __tmp48851 '()))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                  (declare (not safe))
-                                                 (cons __tmp48879
-                                                       __tmp48875))))
+                                                 (cons __tmp48854
+                                                       __tmp48850))))
                                           (declare (not safe))
-                                          (cons __tmp48883 __tmp48874))))
+                                          (cons __tmp48858 __tmp48849))))
                                    (declare (not safe))
-                                   (cons __tmp48873 '()))))
+                                   (cons __tmp48848 '()))))
                             (declare (not safe))
-                            (cons __tmp48884 __tmp48872))))
+                            (cons __tmp48859 __tmp48847))))
                      (declare (not safe))
-                     (cons __tmp48886 __tmp48871))))
+                     (cons __tmp48861 __tmp48846))))
                 (___kont4785547856_
                  (lambda (_L45032_ _L45034_ _L45035_ _L45036_)
-                   (let ((__tmp48904 (gx#datum->syntax '#f 'lambda))
-                         (__tmp48887
-                          (let ((__tmp48902
-                                 (let ((__tmp48903
+                   (let ((__tmp48879 (gx#datum->syntax '#f 'lambda))
+                         (__tmp48862
+                          (let ((__tmp48877
+                                 (let ((__tmp48878
                                         (gx#datum->syntax '#f '$obj)))
                                    (declare (not safe))
-                                   (cons __tmp48903 '())))
-                                (__tmp48888
-                                 (let ((__tmp48889
-                                        (let ((__tmp48901
+                                   (cons __tmp48878 '())))
+                                (__tmp48863
+                                 (let ((__tmp48864
+                                        (let ((__tmp48876
                                                (gx#datum->syntax '#f 'and))
-                                              (__tmp48890
-                                               (let ((__tmp48897
-                                                      (let ((__tmp48898
-                                                             (let ((__tmp48899
+                                              (__tmp48865
+                                               (let ((__tmp48872
+                                                      (let ((__tmp48873
+                                                             (let ((__tmp48874
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                            (let ((__tmp48900 (gx#datum->syntax '#f '$obj)))
+                            (let ((__tmp48875 (gx#datum->syntax '#f '$obj)))
                               (declare (not safe))
-                              (cons __tmp48900 '()))))
+                              (cons __tmp48875 '()))))
                        (declare (not safe))
-                       (cons _L45035_ __tmp48899))))
+                       (cons _L45035_ __tmp48874))))
                 (declare (not safe))
-                (cons _L45036_ __tmp48898)))
+                (cons _L45036_ __tmp48873)))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-                                                     (__tmp48891
-                                                      (let ((__tmp48892
-                                                             (let ((__tmp48893
+                                                     (__tmp48866
+                                                      (let ((__tmp48867
+                                                             (let ((__tmp48868
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                            (let ((__tmp48894
-                                   (let ((__tmp48895
-                                          (let ((__tmp48896
+                            (let ((__tmp48869
+                                   (let ((__tmp48870
+                                          (let ((__tmp48871
                                                  (gx#datum->syntax '#f '$obj)))
                                             (declare (not safe))
-                                            (cons __tmp48896 '()))))
+                                            (cons __tmp48871 '()))))
                                      (declare (not safe))
-                                     (cons _L45034_ __tmp48895))))
+                                     (cons _L45034_ __tmp48870))))
                               (declare (not safe))
-                              (cons __tmp48894 '()))))
+                              (cons __tmp48869 '()))))
                        (declare (not safe))
-                       (cons _L45032_ __tmp48893))))
+                       (cons _L45032_ __tmp48868))))
                 (declare (not safe))
-                (cons __tmp48892 '()))))
+                (cons __tmp48867 '()))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                  (declare (not safe))
-                                                 (cons __tmp48897
-                                                       __tmp48891))))
+                                                 (cons __tmp48872
+                                                       __tmp48866))))
                                           (declare (not safe))
-                                          (cons __tmp48901 __tmp48890))))
+                                          (cons __tmp48876 __tmp48865))))
                                    (declare (not safe))
-                                   (cons __tmp48889 '()))))
+                                   (cons __tmp48864 '()))))
                             (declare (not safe))
-                            (cons __tmp48902 __tmp48888))))
+                            (cons __tmp48877 __tmp48863))))
                      (declare (not safe))
-                     (cons __tmp48904 __tmp48887)))))
+                     (cons __tmp48879 __tmp48862)))))
             (let* ((___match4800748008_
                     (lambda (_e4490745141_
                              _hd4490645145_
@@ -8534,7 +8534,7 @@
                              _tl4491145168_)
                       (if (gx#identifier? _hd4491245165_)
                           (if (gx#free-identifier=?
-                               |gerbil/core/match[1]#_g48906_|
+                               |gerbil/core/match[1]#_g48881_|
                                _hd4491245165_)
                               (if (gx#stx-pair? _tl4491145168_)
                                   (let ((_e4491645171_
@@ -8595,7 +8595,7 @@
                      (let () (declare (not safe)) (##car _e4495245012_))))
                 (if (gx#identifier? _hd4495145016_)
                     (if (gx#free-identifier=?
-                         |gerbil/core/match[1]#_g48905_|
+                         |gerbil/core/match[1]#_g48880_|
                          _hd4495145016_)
                         (if (gx#stx-pair? _tl4495045019_)
                             (let ((_e4495545022_ (gx#syntax-e _tl4495045019_)))
@@ -8652,7 +8652,7 @@
                                          (##car _e4491345161_))))
                                   (if (gx#identifier? _hd4491245165_)
                                       (if (gx#free-identifier=?
-                                           |gerbil/core/match[1]#_g48906_|
+                                           |gerbil/core/match[1]#_g48881_|
                                            _hd4491245165_)
                                           (if (gx#stx-pair? _tl4491145168_)
                                               (let ((_e4491645171_
@@ -8717,7 +8717,7 @@
                                    (##car _e4495245012_))))
                             (if (gx#identifier? _hd4495145016_)
                                 (if (gx#free-identifier=?
-                                     |gerbil/core/match[1]#_g48905_|
+                                     |gerbil/core/match[1]#_g48880_|
                                      _hd4495145016_)
                                     (if (gx#stx-pair? _tl4495045019_)
                                         (let ((_e4495545022_
@@ -8987,7 +8987,7 @@
                                _hd4482445509_)
                               (if (gx#identifier? _hd4489245275_)
                                   (if (gx#free-identifier=?
-                                       |gerbil/core/match[1]#_g48906_|
+                                       |gerbil/core/match[1]#_g48881_|
                                        _hd4489245275_)
                                       (if (gx#stx-pair? _tl4489145278_)
                                           (let ((_e4491645171_
@@ -9053,7 +9053,7 @@
                                (##car _e4495245012_))))
                         (if (gx#identifier? _hd4495145016_)
                             (if (gx#free-identifier=?
-                                 |gerbil/core/match[1]#_g48905_|
+                                 |gerbil/core/match[1]#_g48880_|
                                  _hd4495145016_)
                                 (if (gx#stx-pair? _tl4495045019_)
                                     (let ((_e4495545022_
@@ -9111,7 +9111,7 @@
                       (___kont4784747848_ _hd4489245275_ _hd4482445509_)
                       (if (gx#identifier? _hd4489245275_)
                           (if (gx#free-identifier=?
-                               |gerbil/core/match[1]#_g48906_|
+                               |gerbil/core/match[1]#_g48881_|
                                _hd4489245275_)
                               (if (gx#stx-pair? _tl4489145278_)
                                   (let ((_e4491645171_
@@ -9172,7 +9172,7 @@
                      (let () (declare (not safe)) (##car _e4495245012_))))
                 (if (gx#identifier? _hd4495145016_)
                     (if (gx#free-identifier=?
-                         |gerbil/core/match[1]#_g48905_|
+                         |gerbil/core/match[1]#_g48880_|
                          _hd4495145016_)
                         (if (gx#stx-pair? _tl4495045019_)
                             (let ((_e4495545022_ (gx#syntax-e _tl4495045019_)))
@@ -9214,7 +9214,7 @@
                   (let () (declare (not safe)) (_g4481544961_)))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                               (if (gx#free-identifier=?
-                                                   |gerbil/core/match[1]#_g48908_|
+                                                   |gerbil/core/match[1]#_g48883_|
                                                    _hd4482745519_)
                                                   (if (gx#stx-pair/null?
                                                        _tl4482645522_)
@@ -9261,7 +9261,7 @@
                                    _hd4482445509_)
                                   (if (gx#identifier? _hd4489245275_)
                                       (if (gx#free-identifier=?
-                                           |gerbil/core/match[1]#_g48906_|
+                                           |gerbil/core/match[1]#_g48881_|
                                            _hd4489245275_)
                                           (if (gx#stx-pair? _tl4489145278_)
                                               (let ((_e4491645171_
@@ -9326,7 +9326,7 @@
                                    (##car _e4495245012_))))
                             (if (gx#identifier? _hd4495145016_)
                                 (if (gx#free-identifier=?
-                                     |gerbil/core/match[1]#_g48905_|
+                                     |gerbil/core/match[1]#_g48880_|
                                      _hd4495145016_)
                                     (if (gx#stx-pair? _tl4495045019_)
                                         (let ((_e4495545022_
@@ -9387,7 +9387,7 @@
                           (___kont4784747848_ _hd4489245275_ _hd4482445509_)
                           (if (gx#identifier? _hd4489245275_)
                               (if (gx#free-identifier=?
-                                   |gerbil/core/match[1]#_g48906_|
+                                   |gerbil/core/match[1]#_g48881_|
                                    _hd4489245275_)
                                   (if (gx#stx-pair? _tl4489145278_)
                                       (let ((_e4491645171_
@@ -9450,7 +9450,7 @@
                          (let () (declare (not safe)) (##car _e4495245012_))))
                     (if (gx#identifier? _hd4495145016_)
                         (if (gx#free-identifier=?
-                             |gerbil/core/match[1]#_g48905_|
+                             |gerbil/core/match[1]#_g48880_|
                              _hd4495145016_)
                             (if (gx#stx-pair? _tl4495045019_)
                                 (let ((_e4495545022_
@@ -9491,7 +9491,7 @@
                       (let () (declare (not safe)) (_g4481544961_)))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                   (if (gx#free-identifier=?
-                                                       |gerbil/core/match[1]#_g48907_|
+                                                       |gerbil/core/match[1]#_g48882_|
                                                        _hd4482745519_)
                                                       (if (gx#stx-pair?
                                                            _tl4482645522_)
@@ -9523,7 +9523,7 @@
                                        _hd4482145499_)
                                       (if (gx#identifier? _hd4488145349_)
                                           (if (gx#free-identifier=?
-                                               |gerbil/core/match[1]#_g48906_|
+                                               |gerbil/core/match[1]#_g48881_|
                                                _hd4488145349_)
                                               (if (gx#stx-pair? _tl4488045352_)
                                                   (let ((_e4491645171_
@@ -9590,7 +9590,7 @@
                                        (##car _e4495245012_))))
                                 (if (gx#identifier? _hd4495145016_)
                                     (if (gx#free-identifier=?
-                                         |gerbil/core/match[1]#_g48905_|
+                                         |gerbil/core/match[1]#_g48880_|
                                          _hd4495145016_)
                                         (if (gx#stx-pair? _tl4495045019_)
                                             (let ((_e4495545022_
@@ -9656,7 +9656,7 @@
                                        _hd4482445509_)
                                       (if (gx#identifier? _hd4489245275_)
                                           (if (gx#free-identifier=?
-                                               |gerbil/core/match[1]#_g48906_|
+                                               |gerbil/core/match[1]#_g48881_|
                                                _hd4489245275_)
                                               (if (gx#stx-pair? _tl4489145278_)
                                                   (let ((_e4491645171_
@@ -9723,7 +9723,7 @@
                                        (##car _e4495245012_))))
                                 (if (gx#identifier? _hd4495145016_)
                                     (if (gx#free-identifier=?
-                                         |gerbil/core/match[1]#_g48905_|
+                                         |gerbil/core/match[1]#_g48880_|
                                          _hd4495145016_)
                                         (if (gx#stx-pair? _tl4495045019_)
                                             (let ((_e4495545022_
@@ -9788,7 +9788,7 @@
                                _hd4482445509_)
                               (if (gx#identifier? _hd4489245275_)
                                   (if (gx#free-identifier=?
-                                       |gerbil/core/match[1]#_g48906_|
+                                       |gerbil/core/match[1]#_g48881_|
                                        _hd4489245275_)
                                       (if (gx#stx-pair? _tl4489145278_)
                                           (let ((_e4491645171_
@@ -9854,7 +9854,7 @@
                                (##car _e4495245012_))))
                         (if (gx#identifier? _hd4495145016_)
                             (if (gx#free-identifier=?
-                                 |gerbil/core/match[1]#_g48905_|
+                                 |gerbil/core/match[1]#_g48880_|
                                  _hd4495145016_)
                                 (if (gx#stx-pair? _tl4495045019_)
                                     (let ((_e4495545022_
@@ -9907,7 +9907,7 @@
                           (___kont4784747848_ _hd4489245275_ _hd4482445509_)
                           (if (gx#identifier? _hd4489245275_)
                               (if (gx#free-identifier=?
-                                   |gerbil/core/match[1]#_g48906_|
+                                   |gerbil/core/match[1]#_g48881_|
                                    _hd4489245275_)
                                   (if (gx#stx-pair? _tl4489145278_)
                                       (let ((_e4491645171_
@@ -9970,7 +9970,7 @@
                          (let () (declare (not safe)) (##car _e4495245012_))))
                     (if (gx#identifier? _hd4495145016_)
                         (if (gx#free-identifier=?
-                             |gerbil/core/match[1]#_g48905_|
+                             |gerbil/core/match[1]#_g48880_|
                              _hd4495145016_)
                             (if (gx#stx-pair? _tl4495045019_)
                                 (let ((_e4495545022_
@@ -10030,7 +10030,7 @@
                                                       (if (gx#identifier?
                                                            _hd4489245275_)
                                                           (if (gx#free-identifier=?
-                                                               |gerbil/core/match[1]#_g48906_|
+                                                               |gerbil/core/match[1]#_g48881_|
                                                                _hd4489245275_)
                                                               (if (gx#stx-pair?
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -10090,7 +10090,7 @@
                                                 (if (gx#identifier?
                                                      _hd4495145016_)
                                                     (if (gx#free-identifier=?
-                                                         |gerbil/core/match[1]#_g48905_|
+                                                         |gerbil/core/match[1]#_g48880_|
                                                          _hd4495145016_)
                                                         (if (gx#stx-pair?
                                                              _tl4495045019_)
@@ -10150,7 +10150,7 @@
                                               (if (gx#identifier?
                                                    _hd4489245275_)
                                                   (if (gx#free-identifier=?
-                                                       |gerbil/core/match[1]#_g48906_|
+                                                       |gerbil/core/match[1]#_g48881_|
                                                        _hd4489245275_)
                                                       (if (gx#stx-pair?
                                                            _tl4489145278_)
@@ -10211,7 +10211,7 @@
                                                (##car _e4495245012_))))
                                         (if (gx#identifier? _hd4495145016_)
                                             (if (gx#free-identifier=?
-                                                 |gerbil/core/match[1]#_g48905_|
+                                                 |gerbil/core/match[1]#_g48880_|
                                                  _hd4495145016_)
                                                 (if (gx#stx-pair?
                                                      _tl4495045019_)

--- a/src/bootstrap/gerbil/core/match~2.scm
+++ b/src/bootstrap/gerbil/core/match~2.scm
@@ -1,55 +1,55 @@
 (declare (block) (standard-bindings) (extended-bindings) (inlining-limit 200))
 (begin
-  (define |gerbil/core/match[2]#_g48588_|
+  (define |gerbil/core/match[2]#_g48886_|
     (##structure
      gx#syntax-quote::t
      'macro-object
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/match[2]#_g48590_|
+  (define |gerbil/core/match[2]#_g48888_|
     (##structure
      gx#syntax-quote::t
      'match-macro::t
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/match[2]#_g48592_|
+  (define |gerbil/core/match[2]#_g48890_|
     (##structure
      gx#syntax-quote::t
      'make-match-macro
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/match[2]#_g48594_|
+  (define |gerbil/core/match[2]#_g48892_|
     (##structure
      gx#syntax-quote::t
      'match-macro?
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/match[2]#_g48598_|
+  (define |gerbil/core/match[2]#_g48896_|
     (##structure
      gx#syntax-quote::t
      'match-macro-macro
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/match[2]#_g48602_|
+  (define |gerbil/core/match[2]#_g48900_|
     (##structure
      gx#syntax-quote::t
      'match-macro-macro-set!
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/match[2]#_g48606_|
+  (define |gerbil/core/match[2]#_g48904_|
     (##structure
      gx#syntax-quote::t
      '&match-macro-macro
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/match[2]#_g48610_|
+  (define |gerbil/core/match[2]#_g48908_|
     (##structure
      gx#syntax-quote::t
      '&match-macro-macro-set!
@@ -102,14 +102,14 @@
          '4
          gerbil/core/mop~MOP-2#class-type-info::t
          '#f))
-      (let ((__tmp48586
-             (let ((__tmp48587 |gerbil/core/match[2]#_g48588_|))
+      (let ((__tmp48884
+             (let ((__tmp48885 |gerbil/core/match[2]#_g48886_|))
                (declare (not safe))
-               (cons __tmp48587 '()))))
+               (cons __tmp48885 '()))))
         (declare (not safe))
         (##unchecked-structure-set!
          __obj48157
-         __tmp48586
+         __tmp48884
          '3
          gerbil/core/mop~MOP-2#class-type-info::t
          '#f))
@@ -145,83 +145,83 @@
          '9
          gerbil/core/mop~MOP-2#class-type-info::t
          '#f))
-      (let ((__tmp48589 |gerbil/core/match[2]#_g48590_|))
+      (let ((__tmp48887 |gerbil/core/match[2]#_g48888_|))
         (declare (not safe))
         (##unchecked-structure-set!
          __obj48157
-         __tmp48589
+         __tmp48887
          '10
          gerbil/core/mop~MOP-2#class-type-info::t
          '#f))
-      (let ((__tmp48591 |gerbil/core/match[2]#_g48592_|))
+      (let ((__tmp48889 |gerbil/core/match[2]#_g48890_|))
         (declare (not safe))
         (##unchecked-structure-set!
          __obj48157
-         __tmp48591
+         __tmp48889
          '11
          gerbil/core/mop~MOP-2#class-type-info::t
          '#f))
-      (let ((__tmp48593 |gerbil/core/match[2]#_g48594_|))
+      (let ((__tmp48891 |gerbil/core/match[2]#_g48892_|))
         (declare (not safe))
         (##unchecked-structure-set!
          __obj48157
-         __tmp48593
+         __tmp48891
          '12
          gerbil/core/mop~MOP-2#class-type-info::t
          '#f))
-      (let ((__tmp48595
-             (let ((__tmp48596
-                    (let ((__tmp48597 |gerbil/core/match[2]#_g48598_|))
+      (let ((__tmp48893
+             (let ((__tmp48894
+                    (let ((__tmp48895 |gerbil/core/match[2]#_g48896_|))
                       (declare (not safe))
-                      (cons 'macro __tmp48597))))
+                      (cons 'macro __tmp48895))))
                (declare (not safe))
-               (cons __tmp48596 '()))))
+               (cons __tmp48894 '()))))
         (declare (not safe))
         (##unchecked-structure-set!
          __obj48157
-         __tmp48595
+         __tmp48893
          '13
          gerbil/core/mop~MOP-2#class-type-info::t
          '#f))
-      (let ((__tmp48599
-             (let ((__tmp48600
-                    (let ((__tmp48601 |gerbil/core/match[2]#_g48602_|))
+      (let ((__tmp48897
+             (let ((__tmp48898
+                    (let ((__tmp48899 |gerbil/core/match[2]#_g48900_|))
                       (declare (not safe))
-                      (cons 'macro __tmp48601))))
+                      (cons 'macro __tmp48899))))
                (declare (not safe))
-               (cons __tmp48600 '()))))
+               (cons __tmp48898 '()))))
         (declare (not safe))
         (##unchecked-structure-set!
          __obj48157
-         __tmp48599
+         __tmp48897
          '14
          gerbil/core/mop~MOP-2#class-type-info::t
          '#f))
-      (let ((__tmp48603
-             (let ((__tmp48604
-                    (let ((__tmp48605 |gerbil/core/match[2]#_g48606_|))
+      (let ((__tmp48901
+             (let ((__tmp48902
+                    (let ((__tmp48903 |gerbil/core/match[2]#_g48904_|))
                       (declare (not safe))
-                      (cons 'macro __tmp48605))))
+                      (cons 'macro __tmp48903))))
                (declare (not safe))
-               (cons __tmp48604 '()))))
+               (cons __tmp48902 '()))))
         (declare (not safe))
         (##unchecked-structure-set!
          __obj48157
-         __tmp48603
+         __tmp48901
          '15
          gerbil/core/mop~MOP-2#class-type-info::t
          '#f))
-      (let ((__tmp48607
-             (let ((__tmp48608
-                    (let ((__tmp48609 |gerbil/core/match[2]#_g48610_|))
+      (let ((__tmp48905
+             (let ((__tmp48906
+                    (let ((__tmp48907 |gerbil/core/match[2]#_g48908_|))
                       (declare (not safe))
-                      (cons 'macro __tmp48609))))
+                      (cons 'macro __tmp48907))))
                (declare (not safe))
-               (cons __tmp48608 '()))))
+               (cons __tmp48906 '()))))
         (declare (not safe))
         (##unchecked-structure-set!
          __obj48157
-         __tmp48607
+         __tmp48905
          '16
          gerbil/core/mop~MOP-2#class-type-info::t
          '#f))

--- a/src/bootstrap/gerbil/core/mop~MOP-2~0.scm
+++ b/src/bootstrap/gerbil/core/mop~MOP-2~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/core/mop~MOP-2::timestamp 1710943495)
+  (define gerbil/core/mop~MOP-2::timestamp 1710954834)
   (begin
     (define gerbil/core/mop~MOP-2#class-type-info::t
       (let ((__tmp34653 (list)))

--- a/src/bootstrap/gerbil/core/sugar~2.scm
+++ b/src/bootstrap/gerbil/core/sugar~2.scm
@@ -18,84 +18,84 @@
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/sugar~Sugar-2[1]#_g28416_|
+  (define |gerbil/core/sugar~Sugar-2[1]#_g28331_|
     (##structure
      gx#syntax-quote::t
      'values
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/sugar~Sugar-2[1]#_g28417_|
+  (define |gerbil/core/sugar~Sugar-2[1]#_g28332_|
     (##structure
      gx#syntax-quote::t
      'values
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/sugar~Sugar-2[1]#_g28490_|
+  (define |gerbil/core/sugar~Sugar-2[1]#_g28405_|
     (##structure
      gx#syntax-quote::t
      'quasiquote
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/sugar~Sugar-2[1]#_g28491_|
+  (define |gerbil/core/sugar~Sugar-2[1]#_g28406_|
     (##structure
      gx#syntax-quote::t
      'quote
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/sugar~Sugar-2[1]#_g28493_|
+  (define |gerbil/core/sugar~Sugar-2[1]#_g28408_|
     (##structure
      gx#syntax-quote::t
      'unquote-splicing
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/sugar~Sugar-2[1]#_g28494_|
+  (define |gerbil/core/sugar~Sugar-2[1]#_g28409_|
     (##structure
      gx#syntax-quote::t
      'unquote
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/sugar~Sugar-2[1]#_g28539_|
+  (define |gerbil/core/sugar~Sugar-2[1]#_g28454_|
     (##structure
      gx#syntax-quote::t
      'unquote-splicing
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/sugar~Sugar-2[1]#_g28540_|
+  (define |gerbil/core/sugar~Sugar-2[1]#_g28455_|
     (##structure
      gx#syntax-quote::t
      'unquote-splicing
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/sugar~Sugar-2[1]#_g28541_|
+  (define |gerbil/core/sugar~Sugar-2[1]#_g28456_|
     (##structure
      gx#syntax-quote::t
      'unquote
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/sugar~Sugar-2[1]#_g28542_|
+  (define |gerbil/core/sugar~Sugar-2[1]#_g28457_|
     (##structure
      gx#syntax-quote::t
      'quasiquote
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/sugar~Sugar-2[1]#_g28554_|
+  (define |gerbil/core/sugar~Sugar-2[1]#_g28469_|
     (##structure
      gx#syntax-quote::t
      '<...>
      #f
      (gx#current-expander-context)
      '()))
-  (define |gerbil/core/sugar~Sugar-2[1]#_g28555_|
+  (define |gerbil/core/sugar~Sugar-2[1]#_g28470_|
     (##structure gx#syntax-quote::t '<> #f (gx#current-expander-context) '()))
   (begin
     (define |gerbil/core/sugar~Sugar-2[:0:]#lambda|
@@ -11348,13 +11348,13 @@
                              (lambda (_L21718_ _L21720_) _x21639_))
                             (___kont2624626247_
                              (lambda (_L21679_)
-                               (let ((__tmp28415 (gx#datum->syntax '#f '_))
-                                     (__tmp28414
+                               (let ((__tmp28330 (gx#datum->syntax '#f '_))
+                                     (__tmp28329
                                       (let ()
                                         (declare (not safe))
                                         (cons _L21679_ '()))))
                                  (declare (not safe))
-                                 (cons __tmp28415 __tmp28414)))))
+                                 (cons __tmp28330 __tmp28329)))))
                         (if (gx#stx-pair? ___stx2624126242_)
                             (let ((_e2164921698_
                                    (gx#syntax-e ___stx2624126242_)))
@@ -11417,7 +11417,7 @@
                                        (##car _e2158821612_))))
                                 (if (gx#identifier? _hd2158721616_)
                                     (if (gx#free-identifier=?
-                                         |gerbil/core/sugar~Sugar-2[1]#_g28416_|
+                                         |gerbil/core/sugar~Sugar-2[1]#_g28331_|
                                          _hd2158721616_)
                                         (___kont2627626277_ _tl2158621619_)
                                         (___kont2627826279_))
@@ -11447,7 +11447,7 @@
                                        (##car _e2152821552_))))
                                 (if (gx#identifier? _hd2152721556_)
                                     (if (gx#free-identifier=?
-                                         |gerbil/core/sugar~Sugar-2[1]#_g28417_|
+                                         |gerbil/core/sugar~Sugar-2[1]#_g28332_|
                                          _hd2152721556_)
                                         (___kont2629626297_ _tl2152621559_)
                                         (___kont2629826299_))
@@ -11462,32 +11462,32 @@
                      ___stx2631326314_))))
             (let ((___kont2631626317_
                    (lambda (_L21492_ _L21494_ _L21495_ _L21496_)
-                     (let ((__tmp28418
-                            (let ((__tmp28419
-                                   (let ((__tmp28420
-                                          (let ((__tmp28421
+                     (let ((__tmp28333
+                            (let ((__tmp28334
+                                   (let ((__tmp28335
+                                          (let ((__tmp28336
                                                  (let ()
                                                    (declare (not safe))
                                                    (cons _L21494_ '()))))
                                             (declare (not safe))
-                                            (cons _L21495_ __tmp28421))))
+                                            (cons _L21495_ __tmp28336))))
                                      (declare (not safe))
-                                     (cons __tmp28420 '()))))
+                                     (cons __tmp28335 '()))))
                               (declare (not safe))
-                              (cons __tmp28419 _L21492_))))
+                              (cons __tmp28334 _L21492_))))
                        (declare (not safe))
-                       (cons _L21496_ __tmp28418))))
+                       (cons _L21496_ __tmp28333))))
                   (___kont2631826319_
                    (lambda (_L21414_ _L21416_)
-                     (let ((__tmp28429 (gx#datum->syntax '#f 'and))
-                           (__tmp28422
-                            (let ((__tmp28423
-                                   (let ((__tmp28424
-                                          (let ((__tmp28428
+                     (let ((__tmp28344 (gx#datum->syntax '#f 'and))
+                           (__tmp28337
+                            (let ((__tmp28338
+                                   (let ((__tmp28339
+                                          (let ((__tmp28343
                                                  (gx#datum->syntax '#f 'let))
-                                                (__tmp28425
-                                                 (let ((__tmp28426
-                                                        (let ((__tmp28427
+                                                (__tmp28340
+                                                 (let ((__tmp28341
+                                                        (let ((__tmp28342
                                                                (lambda (_g2143621439_
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                                 _g2143721442_)
@@ -11495,18 +11495,18 @@
                            (declare (not safe))
                            (cons _g2143621439_ _g2143721442_)))))
                   (declare (not safe))
-                  (foldr1 __tmp28427 '() _L21414_))))
+                  (foldr1 __tmp28342 '() _L21414_))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                    (declare (not safe))
-                                                   (cons '() __tmp28426))))
+                                                   (cons '() __tmp28341))))
                                             (declare (not safe))
-                                            (cons __tmp28428 __tmp28425))))
+                                            (cons __tmp28343 __tmp28340))))
                                      (declare (not safe))
-                                     (cons __tmp28424 '()))))
+                                     (cons __tmp28339 '()))))
                               (declare (not safe))
-                              (cons _L21416_ __tmp28423))))
+                              (cons _L21416_ __tmp28338))))
                        (declare (not safe))
-                       (cons __tmp28429 __tmp28422))))
+                       (cons __tmp28344 __tmp28337))))
                   (___kont2632226323_
                    (lambda (_L20981_ _L20983_)
                      (let* ((_g2101421040_
@@ -11518,30 +11518,30 @@
                             (_g2101321325_
                              (lambda (_g2101521044_)
                                (if (gx#stx-pair/null? _g2101521044_)
-                                   (let ((_g28430_
+                                   (let ((_g28345_
                                           (gx#syntax-split-splice
                                            _g2101521044_
                                            '0)))
                                      (begin
-                                       (let ((_g28431_
+                                       (let ((_g28346_
                                               (let ()
                                                 (declare (not safe))
-                                                (if (##values? _g28430_)
-                                                    (##vector-length _g28430_)
+                                                (if (##values? _g28345_)
+                                                    (##vector-length _g28345_)
                                                     1))))
                                          (if (not (let ()
                                                     (declare (not safe))
-                                                    (##fx= _g28431_ 2)))
+                                                    (##fx= _g28346_ 2)))
                                              (error "Context expects 2 values"
-                                                    _g28431_)))
+                                                    _g28346_)))
                                        (let ((_target2101821047_
                                               (let ()
                                                 (declare (not safe))
-                                                (##vector-ref _g28430_ 0)))
+                                                (##vector-ref _g28345_ 0)))
                                              (_tl2102021050_
                                               (let ()
                                                 (declare (not safe))
-                                                (##vector-ref _g28430_ 1))))
+                                                (##vector-ref _g28345_ 1))))
                                          (if (gx#stx-null? _tl2102021050_)
                                              (letrec ((_loop2102121053_
                                                        (lambda (_hd2101921057_
@@ -11609,34 +11609,34 @@
                                    (_g2111821313_
                                     (lambda (_g2112021140_)
                                       (if (gx#stx-pair/null? _g2112021140_)
-                                          (let ((_g28432_
+                                          (let ((_g28347_
                                                  (gx#syntax-split-splice
                                                   _g2112021140_
                                                   '0)))
                                             (begin
-                                              (let ((_g28433_
+                                              (let ((_g28348_
                                                      (let ()
                                                        (declare (not safe))
-                                                       (if (##values? _g28432_)
+                                                       (if (##values? _g28347_)
                                                            (##vector-length
-                                                            _g28432_)
+                                                            _g28347_)
                                                            1))))
                                                 (if (not (let ()
                                                            (declare (not safe))
-                                                           (##fx= _g28433_ 2)))
+                                                           (##fx= _g28348_ 2)))
                                                     (error "Context expects 2 values"
-                                                           _g28433_)))
+                                                           _g28348_)))
                                               (let ((_target2112221143_
                                                      (let ()
                                                        (declare (not safe))
                                                        (##vector-ref
-                                                        _g28432_
+                                                        _g28347_
                                                         0)))
                                                     (_tl2112421146_
                                                      (let ()
                                                        (declare (not safe))
                                                        (##vector-ref
-                                                        _g28432_
+                                                        _g28347_
                                                         1))))
                                                 (if (gx#stx-null?
                                                      _tl2112421146_)
@@ -11672,36 +11672,36 @@
                                            (lambda (_g2119121211_)
                                              (if (gx#stx-pair/null?
                                                   _g2119121211_)
-                                                 (let ((_g28434_
+                                                 (let ((_g28349_
                                                         (gx#syntax-split-splice
                                                          _g2119121211_
                                                          '0)))
                                                    (begin
-                                                     (let ((_g28435_
+                                                     (let ((_g28350_
                                                             (let ()
                                                               (declare
                                                                 (not safe))
                                                               (if (##values?
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                           _g28434_)
-                          (##vector-length _g28434_)
+                           _g28349_)
+                          (##vector-length _g28349_)
                           1))))
-               (if (not (let () (declare (not safe)) (##fx= _g28435_ 2)))
-                   (error "Context expects 2 values" _g28435_)))
+               (if (not (let () (declare (not safe)) (##fx= _g28350_ 2)))
+                   (error "Context expects 2 values" _g28350_)))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (let ((_target2119321214_
                                                             (let ()
                                                               (declare
                                                                 (not safe))
                                                               (##vector-ref
-                                                               _g28434_
+                                                               _g28349_
                                                                0)))
                                                            (_tl2119521217_
                                                             (let ()
                                                               (declare
                                                                 (not safe))
                                                               (##vector-ref
-                                                               _g28434_
+                                                               _g28349_
                                                                1))))
                                                        (if (gx#stx-null?
                                                             _tl2119521217_)
@@ -11730,99 +11730,99 @@
                                      ((lambda (_L21244_)
                                         (let ()
                                           (let ()
-                                            (let ((__tmp28457
+                                            (let ((__tmp28372
                                                    (gx#datum->syntax
                                                     '#f
                                                     'let-values))
-                                                  (__tmp28436
-                                                   (let ((__tmp28452
+                                                  (__tmp28351
+                                                   (let ((__tmp28367
                                                           (begin
                                                             (gx#syntax-check-splice-targets
                                                              _L21101_
                                                              _L21173_)
-                                                            (let ((__tmp28453
+                                                            (let ((__tmp28368
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                            (lambda (_g2126921273_ _g2127021276_ _g2127121278_)
-                             (let ((__tmp28454
-                                    (let ((__tmp28456
+                             (let ((__tmp28369
+                                    (let ((__tmp28371
                                            (let ()
                                              (declare (not safe))
                                              (cons _g2127021276_ '())))
-                                          (__tmp28455
+                                          (__tmp28370
                                            (let ()
                                              (declare (not safe))
                                              (cons _g2126921273_ '()))))
                                       (declare (not safe))
-                                      (cons __tmp28456 __tmp28455))))
+                                      (cons __tmp28371 __tmp28370))))
                                (declare (not safe))
-                               (cons __tmp28454 _g2127121278_)))))
+                               (cons __tmp28369 _g2127121278_)))))
                       (declare (not safe))
-                      (foldr2 __tmp28453 '() _L21101_ _L21173_))))
-                 (__tmp28437
-                  (let ((__tmp28438
-                         (let ((__tmp28451 (gx#datum->syntax '#f 'and))
-                               (__tmp28439
-                                (let ((__tmp28450
+                      (foldr2 __tmp28368 '() _L21101_ _L21173_))))
+                 (__tmp28352
+                  (let ((__tmp28353
+                         (let ((__tmp28366 (gx#datum->syntax '#f 'and))
+                               (__tmp28354
+                                (let ((__tmp28365
                                        (lambda (_g2126221281_ _g2126321284_)
                                          (let ()
                                            (declare (not safe))
                                            (cons _g2126221281_
                                                  _g2126321284_))))
-                                      (__tmp28440
-                                       (let ((__tmp28441
-                                              (let ((__tmp28449
+                                      (__tmp28355
+                                       (let ((__tmp28356
+                                              (let ((__tmp28364
                                                      (gx#datum->syntax
                                                       '#f
                                                       'let-values))
-                                                    (__tmp28442
-                                                     (let ((__tmp28445
+                                                    (__tmp28357
+                                                     (let ((__tmp28360
                                                             (begin
                                                               (gx#syntax-check-splice-targets
                                                                _L21173_
                                                                _L21244_)
-                                                              (let ((__tmp28446
+                                                              (let ((__tmp28361
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                              (lambda (_g2126621287_
                                       _g2126721290_
                                       _g2126821292_)
-                               (let ((__tmp28447
-                                      (let ((__tmp28448
+                               (let ((__tmp28362
+                                      (let ((__tmp28363
                                              (let ()
                                                (declare (not safe))
                                                (cons _g2126621287_ '()))))
                                         (declare (not safe))
-                                        (cons _g2126721290_ __tmp28448))))
+                                        (cons _g2126721290_ __tmp28363))))
                                  (declare (not safe))
-                                 (cons __tmp28447 _g2126821292_)))))
+                                 (cons __tmp28362 _g2126821292_)))))
                         (declare (not safe))
-                        (foldr2 __tmp28446 '() _L21173_ _L21244_))))
-                   (__tmp28443
-                    (let ((__tmp28444
+                        (foldr2 __tmp28361 '() _L21173_ _L21244_))))
+                   (__tmp28358
+                    (let ((__tmp28359
                            (lambda (_g2126421295_ _g2126521298_)
                              (let ()
                                (declare (not safe))
                                (cons _g2126421295_ _g2126521298_)))))
                       (declare (not safe))
-                      (foldr1 __tmp28444 '() _L20981_))))
+                      (foldr1 __tmp28359 '() _L20981_))))
                (declare (not safe))
-               (cons __tmp28445 __tmp28443))))
+               (cons __tmp28360 __tmp28358))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                 (declare (not safe))
-                                                (cons __tmp28449 __tmp28442))))
+                                                (cons __tmp28364 __tmp28357))))
                                          (declare (not safe))
-                                         (cons __tmp28441 '()))))
+                                         (cons __tmp28356 '()))))
                                   (declare (not safe))
-                                  (foldr1 __tmp28450 __tmp28440 _L21173_))))
+                                  (foldr1 __tmp28365 __tmp28355 _L21173_))))
                            (declare (not safe))
-                           (cons __tmp28451 __tmp28439))))
+                           (cons __tmp28366 __tmp28354))))
                     (declare (not safe))
-                    (cons __tmp28438 '()))))
+                    (cons __tmp28353 '()))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (declare (not safe))
-                                                     (cons __tmp28452
-                                                           __tmp28437))))
+                                                     (cons __tmp28367
+                                                           __tmp28352))))
                                               (declare (not safe))
-                                              (cons __tmp28457 __tmp28436)))))
+                                              (cons __tmp28372 __tmp28351)))))
                                       _hd-bind2120121240_))))))
                      (_loop2119621220_ _target2119321214_ '()))
                    (_g2119021207_ _g2119121211_)))))
@@ -11832,7 +11832,7 @@
                                      (_g2118921301_
                                       (gx#stx-map
                                        _let-head20818_
-                                       (let ((__tmp28458
+                                       (let ((__tmp28373
                                               (lambda (_g2130421307_
                                                        _g2130521310_)
                                                 (let ()
@@ -11840,7 +11840,7 @@
                                                   (cons _g2130421307_
                                                         _g2130521310_)))))
                                          (declare (not safe))
-                                         (foldr1 __tmp28458 '() _L21103_)))))))
+                                         (foldr1 __tmp28373 '() _L21103_)))))))
                                _$e2113021169_))))))
               (_loop2112521149_ _target2112221143_ '()))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -11849,14 +11849,14 @@
                                           (_g2111921136_ _g2112021140_)))))
                               (_g2111821313_
                                (gx#gentemps
-                                (let ((__tmp28459
+                                (let ((__tmp28374
                                        (lambda (_g2131621319_ _g2131721322_)
                                          (let ()
                                            (declare (not safe))
                                            (cons _g2131621319_
                                                  _g2131721322_)))))
                                   (declare (not safe))
-                                  (foldr1 __tmp28459 '() _L21103_)))))))
+                                  (foldr1 __tmp28374 '() _L21103_)))))))
                         _e2102721095_
                         _hd2102821098_))))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -11869,13 +11869,13 @@
                        (_g2101321325_
                         (gx#stx-map
                          _let-bind20816_
-                         (let ((__tmp28460
+                         (let ((__tmp28375
                                 (lambda (_g2132821331_ _g2132921334_)
                                   (let ()
                                     (declare (not safe))
                                     (cons _g2132821331_ _g2132921334_)))))
                            (declare (not safe))
-                           (foldr1 __tmp28460 '() _L20983_))))))))
+                           (foldr1 __tmp28375 '() _L20983_))))))))
               (let* ((___match2641026411_
                       (lambda (_e2086720901_
                                _hd2086620905_
@@ -11954,7 +11954,7 @@
                                       (_L20983_ _bind2087920947_))
                                   (if (gx#stx-andmap
                                        _let-bind?20814_
-                                       (let ((__tmp28461
+                                       (let ((__tmp28376
                                               (lambda (_g2100521008_
                                                        _g2100621011_)
                                                 (let ()
@@ -11962,7 +11962,7 @@
                                                   (cons _g2100521008_
                                                         _g2100621011_)))))
                                          (declare (not safe))
-                                         (foldr1 __tmp28461 '() _L20983_)))
+                                         (foldr1 __tmp28376 '() _L20983_)))
                                       (___kont2632226323_ _L20981_ _L20983_)
                                       (let ()
                                         (declare (not safe))
@@ -12475,34 +12475,34 @@
           (let ((___kont2641626417_ (lambda () '#t))
                 (___kont2641826419_
                  (lambda (_L22069_)
-                   (let ((__tmp28465 (gx#datum->syntax '#f 'let))
-                         (__tmp28462
-                          (let ((__tmp28463
-                                 (let ((__tmp28464
+                   (let ((__tmp28380 (gx#datum->syntax '#f 'let))
+                         (__tmp28377
+                          (let ((__tmp28378
+                                 (let ((__tmp28379
                                         (lambda (_g2208522088_ _g2208622091_)
                                           (let ()
                                             (declare (not safe))
                                             (cons _g2208522088_
                                                   _g2208622091_)))))
                                    (declare (not safe))
-                                   (foldr1 __tmp28464 '() _L22069_))))
+                                   (foldr1 __tmp28379 '() _L22069_))))
                             (declare (not safe))
-                            (cons '() __tmp28463))))
+                            (cons '() __tmp28378))))
                      (declare (not safe))
-                     (cons __tmp28465 __tmp28462))))
+                     (cons __tmp28380 __tmp28377))))
                 (___kont2642226423_
                  (lambda (_L21978_ _L21980_ _L21981_ _L21982_)
-                   (let ((__tmp28473 (gx#datum->syntax '#f 'alet))
-                         (__tmp28466
-                          (let ((__tmp28472
+                   (let ((__tmp28388 (gx#datum->syntax '#f 'alet))
+                         (__tmp28381
+                          (let ((__tmp28387
                                  (let ()
                                    (declare (not safe))
                                    (cons _L21981_ '())))
-                                (__tmp28467
-                                 (let ((__tmp28468
-                                        (let ((__tmp28469
-                                               (let ((__tmp28470
-                                                      (let ((__tmp28471
+                                (__tmp28382
+                                 (let ((__tmp28383
+                                        (let ((__tmp28384
+                                               (let ((__tmp28385
+                                                      (let ((__tmp28386
                                                              (lambda (_g2200322006_
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                               _g2200422009_)
@@ -12510,18 +12510,18 @@
                          (declare (not safe))
                          (cons _g2200322006_ _g2200422009_)))))
                 (declare (not safe))
-                (foldr1 __tmp28471 '() _L21978_))))
+                (foldr1 __tmp28386 '() _L21978_))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                  (declare (not safe))
-                                                 (cons _L21980_ __tmp28470))))
+                                                 (cons _L21980_ __tmp28385))))
                                           (declare (not safe))
-                                          (cons _L21982_ __tmp28469))))
+                                          (cons _L21982_ __tmp28384))))
                                    (declare (not safe))
-                                   (cons __tmp28468 '()))))
+                                   (cons __tmp28383 '()))))
                             (declare (not safe))
-                            (cons __tmp28472 __tmp28467))))
+                            (cons __tmp28387 __tmp28382))))
                      (declare (not safe))
-                     (cons __tmp28473 __tmp28466)))))
+                     (cons __tmp28388 __tmp28381)))))
             (let* ((___match2649026491_
                     (lambda (_e2189021918_
                              _hd2188921922_
@@ -12717,62 +12717,62 @@
                    ___stx2649326494_))))
           (let ((___kont2649626497_
                  (lambda ()
-                   (let ((__tmp28475 (gx#datum->syntax '#f 'quote))
-                         (__tmp28474
+                   (let ((__tmp28390 (gx#datum->syntax '#f 'quote))
+                         (__tmp28389
                           (let () (declare (not safe)) (cons '() '()))))
                      (declare (not safe))
-                     (cons __tmp28475 __tmp28474))))
+                     (cons __tmp28390 __tmp28389))))
                 (___kont2649826499_
                  (lambda (_L22551_)
-                   (let ((__tmp28477 (gx#datum->syntax '#f 'quote))
-                         (__tmp28476
+                   (let ((__tmp28392 (gx#datum->syntax '#f 'quote))
+                         (__tmp28391
                           (let () (declare (not safe)) (cons _L22551_ '()))))
                      (declare (not safe))
-                     (cons __tmp28477 __tmp28476))))
+                     (cons __tmp28392 __tmp28391))))
                 (___kont2650026501_
                  (lambda (_L22499_)
-                   (let ((__tmp28479 (gx#datum->syntax '#f 'quasiquote))
-                         (__tmp28478
+                   (let ((__tmp28394 (gx#datum->syntax '#f 'quasiquote))
+                         (__tmp28393
                           (let () (declare (not safe)) (cons _L22499_ '()))))
                      (declare (not safe))
-                     (cons __tmp28479 __tmp28478))))
+                     (cons __tmp28394 __tmp28393))))
                 (___kont2650226503_ (lambda (_L22446_) _L22446_))
                 (___kont2650426505_ (lambda (_L22388_ _L22390_) _L22390_))
                 (___kont2650626507_
                  (lambda (_L22330_ _L22332_ _L22333_ _L22334_)
-                   (let ((__tmp28485 (gx#datum->syntax '#f 'foldr))
-                         (__tmp28480
-                          (let ((__tmp28484 (gx#datum->syntax '#f 'cons))
-                                (__tmp28481
-                                 (let ((__tmp28483
+                   (let ((__tmp28400 (gx#datum->syntax '#f 'foldr))
+                         (__tmp28395
+                          (let ((__tmp28399 (gx#datum->syntax '#f 'cons))
+                                (__tmp28396
+                                 (let ((__tmp28398
                                         (let ()
                                           (declare (not safe))
                                           (cons _L22334_ _L22330_)))
-                                       (__tmp28482
+                                       (__tmp28397
                                         (let ()
                                           (declare (not safe))
                                           (cons _L22333_ '()))))
                                    (declare (not safe))
-                                   (cons __tmp28483 __tmp28482))))
+                                   (cons __tmp28398 __tmp28397))))
                             (declare (not safe))
-                            (cons __tmp28484 __tmp28481))))
+                            (cons __tmp28399 __tmp28396))))
                      (declare (not safe))
-                     (cons __tmp28485 __tmp28480))))
+                     (cons __tmp28400 __tmp28395))))
                 (___kont2650826509_
                  (lambda (_L22276_ _L22278_ _L22279_)
-                   (let ((__tmp28489 (gx#datum->syntax '#f 'cons))
-                         (__tmp28486
-                          (let ((__tmp28487
-                                 (let ((__tmp28488
+                   (let ((__tmp28404 (gx#datum->syntax '#f 'cons))
+                         (__tmp28401
+                          (let ((__tmp28402
+                                 (let ((__tmp28403
                                         (let ()
                                           (declare (not safe))
                                           (cons _L22279_ _L22276_))))
                                    (declare (not safe))
-                                   (cons __tmp28488 '()))))
+                                   (cons __tmp28403 '()))))
                             (declare (not safe))
-                            (cons _L22278_ __tmp28487))))
+                            (cons _L22278_ __tmp28402))))
                      (declare (not safe))
-                     (cons __tmp28489 __tmp28486))))
+                     (cons __tmp28404 __tmp28401))))
                 (___kont2651026511_ (lambda (_L22237_) _L22237_)))
             (let* ((___match2663226633_
                     (lambda (_e2219522300_
@@ -12845,7 +12845,7 @@
                                          (##car _e2215322531_))))
                                   (if (gx#identifier? _hd2215222535_)
                                       (if (gx#free-identifier=?
-                                           |gerbil/core/sugar~Sugar-2[1]#_g28491_|
+                                           |gerbil/core/sugar~Sugar-2[1]#_g28406_|
                                            _hd2215222535_)
                                           (if (gx#stx-pair? _tl2215122538_)
                                               (let ((_e2215622541_
@@ -12878,7 +12878,7 @@
                                                _hd2215222535_
                                                _hd2214522577_))
                                           (if (gx#free-identifier=?
-                                               |gerbil/core/sugar~Sugar-2[1]#_g28490_|
+                                               |gerbil/core/sugar~Sugar-2[1]#_g28405_|
                                                _hd2215222535_)
                                               (if (gx#stx-pair? _tl2215122538_)
                                                   (let ((_e2216622489_
@@ -13088,14 +13088,14 @@
                             (___kont2666226663_
                              (lambda (_L23406_)
                                (_simple-quote?22594_
-                                (let ((__tmp28492
+                                (let ((__tmp28407
                                        (lambda (_g2341923422_ _g2342023425_)
                                          (let ()
                                            (declare (not safe))
                                            (cons _g2341923422_
                                                  _g2342023425_)))))
                                   (declare (not safe))
-                                  (foldr1 __tmp28492 '() _L23406_)))))
+                                  (foldr1 __tmp28407 '() _L23406_)))))
                             (___kont2666626667_
                              (lambda (_L23353_)
                                (_simple-quote?22594_ _L23353_)))
@@ -13192,7 +13192,7 @@
                                          (##car _e2329823496_))))
                                   (if (gx#identifier? _hd2329723500_)
                                       (if (gx#free-identifier=?
-                                           |gerbil/core/sugar~Sugar-2[1]#_g28494_|
+                                           |gerbil/core/sugar~Sugar-2[1]#_g28409_|
                                            _hd2329723500_)
                                           (if (gx#stx-pair? _tl2329623503_)
                                               (let ((_e2330123506_
@@ -13216,7 +13216,7 @@
                                                _tl2329623503_
                                                _hd2329723500_))
                                           (if (gx#free-identifier=?
-                                               |gerbil/core/sugar~Sugar-2[1]#_g28493_|
+                                               |gerbil/core/sugar~Sugar-2[1]#_g28408_|
                                                _hd2329723500_)
                                               (if (gx#stx-pair? _tl2329623503_)
                                                   (let ((_e2330723475_
@@ -13271,29 +13271,29 @@
                                        (lambda (_g2325223263_)
                                          ((lambda (_L23266_)
                                             (let ()
-                                              (let ((__tmp28501
+                                              (let ((__tmp28416
                                                      (gx#datum->syntax
                                                       '#f
                                                       'list))
-                                                    (__tmp28495
-                                                     (let ((__tmp28497
-                                                            (let ((__tmp28500
+                                                    (__tmp28410
+                                                     (let ((__tmp28412
+                                                            (let ((__tmp28415
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                            (gx#datum->syntax '#f 'quote))
-                          (__tmp28498
-                           (let ((__tmp28499
+                          (__tmp28413
+                           (let ((__tmp28414
                                   (gx#datum->syntax '#f 'quasiquote)))
                              (declare (not safe))
-                             (cons __tmp28499 '()))))
+                             (cons __tmp28414 '()))))
                       (declare (not safe))
-                      (cons __tmp28500 __tmp28498)))
-                   (__tmp28496
+                      (cons __tmp28415 __tmp28413)))
+                   (__tmp28411
                     (let () (declare (not safe)) (cons _L23266_ '()))))
                (declare (not safe))
-               (cons __tmp28497 __tmp28496))))
+               (cons __tmp28412 __tmp28411))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                 (declare (not safe))
-                                                (cons __tmp28501 __tmp28495))))
+                                                (cons __tmp28416 __tmp28410))))
                                           _g2325223263_))))
                                  (_g2325023278_
                                   (_generate22596_
@@ -13317,30 +13317,30 @@
                                            (lambda (_g2318123192_)
                                              ((lambda (_L23195_)
                                                 (let ()
-                                                  (let ((__tmp28508
+                                                  (let ((__tmp28423
                                                          (gx#datum->syntax
                                                           '#f
                                                           'list))
-                                                        (__tmp28502
-                                                         (let ((__tmp28504
-                                                                (let ((__tmp28507
+                                                        (__tmp28417
+                                                         (let ((__tmp28419
+                                                                (let ((__tmp28422
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                                (gx#datum->syntax '#f 'quote))
-                              (__tmp28505
-                               (let ((__tmp28506
+                              (__tmp28420
+                               (let ((__tmp28421
                                       (gx#datum->syntax '#f 'unquote)))
                                  (declare (not safe))
-                                 (cons __tmp28506 '()))))
+                                 (cons __tmp28421 '()))))
                           (declare (not safe))
-                          (cons __tmp28507 __tmp28505)))
-                       (__tmp28503
+                          (cons __tmp28422 __tmp28420)))
+                       (__tmp28418
                         (let () (declare (not safe)) (cons _L23195_ '()))))
                    (declare (not safe))
-                   (cons __tmp28504 __tmp28503))))
+                   (cons __tmp28419 __tmp28418))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                     (declare (not safe))
-                                                    (cons __tmp28508
-                                                          __tmp28502))))
+                                                    (cons __tmp28423
+                                                          __tmp28417))))
                                               _g2318123192_))))
                                      (_g2317923207_
                                       (_generate22596_
@@ -13353,33 +13353,33 @@
                                (if (let ()
                                      (declare (not safe))
                                      (fxzero? _d22660_))
-                                   (let ((__tmp28523
+                                   (let ((__tmp28438
                                           (gx#datum->syntax '#f 'foldr))
-                                         (__tmp28516
-                                          (let ((__tmp28522
+                                         (__tmp28431
+                                          (let ((__tmp28437
                                                  (gx#datum->syntax '#f 'cons))
-                                                (__tmp28517
-                                                 (let ((__tmp28519
-                                                        (let ((__tmp28521
+                                                (__tmp28432
+                                                 (let ((__tmp28434
+                                                        (let ((__tmp28436
                                                                (gx#datum->syntax
                                                                 '#f
                                                                 'quote))
-                                                              (__tmp28520
+                                                              (__tmp28435
                                                                (let ()
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                          (declare (not safe))
                          (cons '() '()))))
                   (declare (not safe))
-                  (cons __tmp28521 __tmp28520)))
-               (__tmp28518 (let () (declare (not safe)) (cons _L23096_ '()))))
+                  (cons __tmp28436 __tmp28435)))
+               (__tmp28433 (let () (declare (not safe)) (cons _L23096_ '()))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                    (declare (not safe))
-                                                   (cons __tmp28519
-                                                         __tmp28518))))
+                                                   (cons __tmp28434
+                                                         __tmp28433))))
                                             (declare (not safe))
-                                            (cons __tmp28522 __tmp28517))))
+                                            (cons __tmp28437 __tmp28432))))
                                      (declare (not safe))
-                                     (cons __tmp28523 __tmp28516))
+                                     (cons __tmp28438 __tmp28431))
                                    (let* ((_g2310923117_
                                            (lambda (_g2311023113_)
                                              (gx#raise-syntax-error
@@ -13390,32 +13390,32 @@
                                            (lambda (_g2311023121_)
                                              ((lambda (_L23124_)
                                                 (let ()
-                                                  (let ((__tmp28515
+                                                  (let ((__tmp28430
                                                          (gx#datum->syntax
                                                           '#f
                                                           'list))
-                                                        (__tmp28509
-                                                         (let ((__tmp28511
-                                                                (let ((__tmp28514
+                                                        (__tmp28424
+                                                         (let ((__tmp28426
+                                                                (let ((__tmp28429
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                                (gx#datum->syntax '#f 'quote))
-                              (__tmp28512
-                               (let ((__tmp28513
+                              (__tmp28427
+                               (let ((__tmp28428
                                       (gx#datum->syntax
                                        '#f
                                        'unquote-splicing)))
                                  (declare (not safe))
-                                 (cons __tmp28513 '()))))
+                                 (cons __tmp28428 '()))))
                           (declare (not safe))
-                          (cons __tmp28514 __tmp28512)))
-                       (__tmp28510
+                          (cons __tmp28429 __tmp28427)))
+                       (__tmp28425
                         (let () (declare (not safe)) (cons _L23124_ '()))))
                    (declare (not safe))
-                   (cons __tmp28511 __tmp28510))))
+                   (cons __tmp28426 __tmp28425))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                     (declare (not safe))
-                                                    (cons __tmp28515
-                                                          __tmp28509))))
+                                                    (cons __tmp28430
+                                                          __tmp28424))))
                                               _g2311023121_))))
                                      (_g2310823136_
                                       (_generate22596_
@@ -13435,26 +13435,26 @@
                                        (lambda (_g2303923050_)
                                          ((lambda (_L23053_)
                                             (let ()
-                                              (let ((__tmp28528
+                                              (let ((__tmp28443
                                                      (gx#datum->syntax
                                                       '#f
                                                       'foldr))
-                                                    (__tmp28524
-                                                     (let ((__tmp28527
+                                                    (__tmp28439
+                                                     (let ((__tmp28442
                                                             (gx#datum->syntax
                                                              '#f
                                                              'cons))
-                                                           (__tmp28525
-                                                            (let ((__tmp28526
+                                                           (__tmp28440
+                                                            (let ((__tmp28441
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                            (let () (declare (not safe)) (cons _L23023_ '()))))
                       (declare (not safe))
-                      (cons _L23053_ __tmp28526))))
+                      (cons _L23053_ __tmp28441))))
                (declare (not safe))
-               (cons __tmp28527 __tmp28525))))
+               (cons __tmp28442 __tmp28440))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                 (declare (not safe))
-                                                (cons __tmp28528 __tmp28524))))
+                                                (cons __tmp28443 __tmp28439))))
                                           _g2303923050_))))
                                  (_g2303723065_
                                   (_generate22596_ _L23021_ _d22660_)))))
@@ -13496,16 +13496,16 @@
                  (if (gx#stx-null? _tl2292722959_)
                      ((lambda (_L22962_ _L22964_)
                         (let ()
-                          (let ((__tmp28531 (gx#datum->syntax '#f 'cons))
-                                (__tmp28529
-                                 (let ((__tmp28530
+                          (let ((__tmp28446 (gx#datum->syntax '#f 'cons))
+                                (__tmp28444
+                                 (let ((__tmp28445
                                         (let ()
                                           (declare (not safe))
                                           (cons _L22962_ '()))))
                                    (declare (not safe))
-                                   (cons _L22964_ __tmp28530))))
+                                   (cons _L22964_ __tmp28445))))
                             (declare (not safe))
-                            (cons __tmp28531 __tmp28529))))
+                            (cons __tmp28446 __tmp28444))))
                       _hd2292822956_
                       _hd2292522946_)
                      (_g2292022935_ _g2292122939_))))
@@ -13530,27 +13530,27 @@
                                        (lambda (_g2285222863_)
                                          ((lambda (_L22866_)
                                             (let ()
-                                              (let ((__tmp28533
+                                              (let ((__tmp28448
                                                      (gx#datum->syntax
                                                       '#f
                                                       'list->vector))
-                                                    (__tmp28532
+                                                    (__tmp28447
                                                      (let ()
                                                        (declare (not safe))
                                                        (cons _L22866_ '()))))
                                                 (declare (not safe))
-                                                (cons __tmp28533 __tmp28532))))
+                                                (cons __tmp28448 __tmp28447))))
                                           _g2285222863_))))
                                  (_g2285022878_
                                   (_generate22596_
-                                   (let ((__tmp28534
+                                   (let ((__tmp28449
                                           (lambda (_g2288122884_ _g2288222887_)
                                             (let ()
                                               (declare (not safe))
                                               (cons _g2288122884_
                                                     _g2288222887_)))))
                                      (declare (not safe))
-                                     (foldr1 __tmp28534 '() _L22837_))
+                                     (foldr1 __tmp28449 '() _L22837_))
                                    _d22660_)))))
                             (___kont2674826749_
                              (lambda (_L22755_)
@@ -13564,28 +13564,28 @@
                                        (lambda (_g2276622777_)
                                          ((lambda (_L22780_)
                                             (let ()
-                                              (let ((__tmp28536
+                                              (let ((__tmp28451
                                                      (gx#datum->syntax
                                                       '#f
                                                       'box))
-                                                    (__tmp28535
+                                                    (__tmp28450
                                                      (let ()
                                                        (declare (not safe))
                                                        (cons _L22780_ '()))))
                                                 (declare (not safe))
-                                                (cons __tmp28536 __tmp28535))))
+                                                (cons __tmp28451 __tmp28450))))
                                           _g2276622777_))))
                                  (_g2276422792_
                                   (_generate22596_ _L22755_ _d22660_)))))
                             (___kont2675026751_
                              (lambda (_L22734_)
-                               (let ((__tmp28538 (gx#datum->syntax '#f 'quote))
-                                     (__tmp28537
+                               (let ((__tmp28453 (gx#datum->syntax '#f 'quote))
+                                     (__tmp28452
                                       (let ()
                                         (declare (not safe))
                                         (cons _L22734_ '()))))
                                  (declare (not safe))
-                                 (cons __tmp28538 __tmp28537)))))
+                                 (cons __tmp28453 __tmp28452)))))
                         (let* ((_g2266722796_
                                 (lambda ()
                                   (if (gx#stx-box? ___stx2673126732_)
@@ -13680,7 +13680,7 @@
                                          (##car _e2267423218_))))
                                   (if (gx#identifier? _hd2267323222_)
                                       (if (gx#free-identifier=?
-                                           |gerbil/core/sugar~Sugar-2[1]#_g28542_|
+                                           |gerbil/core/sugar~Sugar-2[1]#_g28457_|
                                            _hd2267323222_)
                                           (if (gx#stx-pair? _tl2267223225_)
                                               (let ((_e2267723228_
@@ -13705,7 +13705,7 @@
                                                _tl2267223225_
                                                _hd2267323222_))
                                           (if (gx#free-identifier=?
-                                               |gerbil/core/sugar~Sugar-2[1]#_g28541_|
+                                               |gerbil/core/sugar~Sugar-2[1]#_g28456_|
                                                _hd2267323222_)
                                               (if (gx#stx-pair? _tl2267223225_)
                                                   (let ((_e2268423157_
@@ -13732,7 +13732,7 @@
                                                    _tl2267223225_
                                                    _hd2267323222_))
                                               (if (gx#free-identifier=?
-                                                   |gerbil/core/sugar~Sugar-2[1]#_g28540_|
+                                                   |gerbil/core/sugar~Sugar-2[1]#_g28455_|
                                                    _hd2267323222_)
                                                   (if (gx#stx-pair?
                                                        _tl2267223225_)
@@ -13768,7 +13768,7 @@
                                               (if (gx#identifier?
                                                    _hd2269823005_)
                                                   (if (gx#free-identifier=?
-                                                       |gerbil/core/sugar~Sugar-2[1]#_g28539_|
+                                                       |gerbil/core/sugar~Sugar-2[1]#_g28454_|
                                                        _hd2269823005_)
                                                       (if (gx#stx-pair?
                                                            _tl2269723008_)
@@ -13834,16 +13834,16 @@
                                     (if (gx#stx-null? _tl2260422636_)
                                         ((lambda (_L22639_)
                                            (if (_simple-quote?22594_ _L22639_)
-                                               (let ((__tmp28544
+                                               (let ((__tmp28459
                                                       (gx#datum->syntax
                                                        '#f
                                                        'quote))
-                                                     (__tmp28543
+                                                     (__tmp28458
                                                       (let ()
                                                         (declare (not safe))
                                                         (cons _L22639_ '()))))
                                                  (declare (not safe))
-                                                 (cons __tmp28544 __tmp28543))
+                                                 (cons __tmp28459 __tmp28458))
                                                (_generate22596_ _L22639_ '0)))
                                          _hd2260522633_)
                                         (_g2259822612_ _g2259922616_))))
@@ -13861,31 +13861,31 @@
                    ___stx2685726858_))))
           (let ((___kont2686026861_
                  (lambda (_L23620_)
-                   (let ((__tmp28546 (gx#datum->syntax '#f 'quote))
-                         (__tmp28545
+                   (let ((__tmp28461 (gx#datum->syntax '#f 'quote))
+                         (__tmp28460
                           (let () (declare (not safe)) (cons _L23620_ '()))))
                      (declare (not safe))
-                     (cons __tmp28546 __tmp28545))))
+                     (cons __tmp28461 __tmp28460))))
                 (___kont2686226863_
                  (lambda (_L23579_)
-                   (let ((__tmp28552 (gx#datum->syntax '#f 'make-promise))
-                         (__tmp28547
-                          (let ((__tmp28548
-                                 (let ((__tmp28551
+                   (let ((__tmp28467 (gx#datum->syntax '#f 'make-promise))
+                         (__tmp28462
+                          (let ((__tmp28463
+                                 (let ((__tmp28466
                                         (gx#datum->syntax '#f 'lambda%))
-                                       (__tmp28549
-                                        (let ((__tmp28550
+                                       (__tmp28464
+                                        (let ((__tmp28465
                                                (let ()
                                                  (declare (not safe))
                                                  (cons _L23579_ '()))))
                                           (declare (not safe))
-                                          (cons '() __tmp28550))))
+                                          (cons '() __tmp28465))))
                                    (declare (not safe))
-                                   (cons __tmp28551 __tmp28549))))
+                                   (cons __tmp28466 __tmp28464))))
                             (declare (not safe))
-                            (cons __tmp28548 '()))))
+                            (cons __tmp28463 '()))))
                      (declare (not safe))
-                     (cons __tmp28552 __tmp28547)))))
+                     (cons __tmp28467 __tmp28462)))))
             (let ((___match2687826879_
                    (lambda (_e2353623600_
                             _hd2353523604_
@@ -13975,9 +13975,9 @@
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                             _tail23859_
                             _hd23767_))
-                  (let ((__tmp28553 (list _tail23859_)))
+                  (let ((__tmp28468 (list _tail23859_)))
                     (declare (not safe))
-                    (foldl1 cons __tmp28553 _body23768_))
+                    (foldl1 cons __tmp28468 _body23768_))
                   '#t))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                 (gx#raise-syntax-error
@@ -13995,11 +13995,11 @@
                                                (cons _L23813_ _body23768_))))))
                                      (if (gx#identifier? ___stx2689526896_)
                                          (if (gx#free-identifier=?
-                                              |gerbil/core/sugar~Sugar-2[1]#_g28555_|
+                                              |gerbil/core/sugar~Sugar-2[1]#_g28470_|
                                               ___stx2689526896_)
                                              (___kont2689826899_)
                                              (if (gx#free-identifier=?
-                                                  |gerbil/core/sugar~Sugar-2[1]#_g28554_|
+                                                  |gerbil/core/sugar~Sugar-2[1]#_g28469_|
                                                   ___stx2689526896_)
                                                  (___kont2690026901_)
                                                  (___kont2690226903_)))
@@ -14044,35 +14044,35 @@
                                    (##cdr _e2364823661_))))
                             ((lambda (_L23671_)
                                (if (and (gx#stx-list? _L23671_)
-                                        (let ((__tmp28566
+                                        (let ((__tmp28481
                                                (gx#stx-null? _L23671_)))
                                           (declare (not safe))
-                                          (not __tmp28566)))
-                                   (let ((_g28556_ (_generate23640_ _L23671_)))
+                                          (not __tmp28481)))
+                                   (let ((_g28471_ (_generate23640_ _L23671_)))
                                      (begin
-                                       (let ((_g28557_
+                                       (let ((_g28472_
                                               (let ()
                                                 (declare (not safe))
-                                                (if (##values? _g28556_)
-                                                    (##vector-length _g28556_)
+                                                (if (##values? _g28471_)
+                                                    (##vector-length _g28471_)
                                                     1))))
                                          (if (not (let ()
                                                     (declare (not safe))
-                                                    (##fx= _g28557_ 3)))
+                                                    (##fx= _g28472_ 3)))
                                              (error "Context expects 3 values"
-                                                    _g28557_)))
+                                                    _g28472_)))
                                        (let ((_hd23684_
                                               (let ()
                                                 (declare (not safe))
-                                                (##vector-ref _g28556_ 0)))
+                                                (##vector-ref _g28471_ 0)))
                                              (_body23686_
                                               (let ()
                                                 (declare (not safe))
-                                                (##vector-ref _g28556_ 1)))
+                                                (##vector-ref _g28471_ 1)))
                                              (_tail?23687_
                                               (let ()
                                                 (declare (not safe))
-                                                (##vector-ref _g28556_ 2))))
+                                                (##vector-ref _g28471_ 2))))
                                          (let* ((_g2368923697_
                                                  (lambda (_g2369023693_)
                                                    (gx#raise-syntax-error
@@ -14096,34 +14096,34 @@
                              (let ()
                                (let ()
                                  (if _tail?23687_
-                                     (let ((__tmp28565
+                                     (let ((__tmp28480
                                             (gx#datum->syntax '#f 'lambda%))
-                                           (__tmp28561
-                                            (let ((__tmp28562
-                                                   (let ((__tmp28563
-                                                          (let ((__tmp28564
+                                           (__tmp28476
+                                            (let ((__tmp28477
+                                                   (let ((__tmp28478
+                                                          (let ((__tmp28479
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                          (gx#datum->syntax '#f 'apply)))
                     (declare (not safe))
-                    (cons __tmp28564 _L23732_))))
+                    (cons __tmp28479 _L23732_))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                      (declare (not safe))
-                                                     (cons __tmp28563 '()))))
+                                                     (cons __tmp28478 '()))))
                                               (declare (not safe))
-                                              (cons _L23704_ __tmp28562))))
+                                              (cons _L23704_ __tmp28477))))
                                        (declare (not safe))
-                                       (cons __tmp28565 __tmp28561))
-                                     (let ((__tmp28560
+                                       (cons __tmp28480 __tmp28476))
+                                     (let ((__tmp28475
                                             (gx#datum->syntax '#f 'lambda%))
-                                           (__tmp28558
-                                            (let ((__tmp28559
+                                           (__tmp28473
+                                            (let ((__tmp28474
                                                    (let ()
                                                      (declare (not safe))
                                                      (cons _L23732_ '()))))
                                               (declare (not safe))
-                                              (cons _L23704_ __tmp28559))))
+                                              (cons _L23704_ __tmp28474))))
                                        (declare (not safe))
-                                       (cons __tmp28560 __tmp28558))))))
+                                       (cons __tmp28475 __tmp28473))))))
                            _g2371823729_))))
                   (_g2371623747_ _body23686_))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/src/bootstrap/gerbil/core/sugar~3.scm
+++ b/src/bootstrap/gerbil/core/sugar~3.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings) (inlining-limit 200))
 (begin
-  (define |gerbil/core/sugar~Sugar-3[1]#_g28413_|
+  (define |gerbil/core/sugar~Sugar-3[1]#_g28566_|
     (##structure
      gx#syntax-quote::t
      'quote
@@ -19,15 +19,15 @@
                    ___stx2693126932_))))
           (let ((___kont2693426935_
                  (lambda (_L24081_ _L24083_ _L24084_)
-                   (let ((__tmp28336 (gx#datum->syntax '#f 'define-syntax))
-                         (__tmp28329
-                          (let ((__tmp28330
-                                 (let ((__tmp28331
-                                        (let ((__tmp28335
+                   (let ((__tmp28489 (gx#datum->syntax '#f 'define-syntax))
+                         (__tmp28482
+                          (let ((__tmp28483
+                                 (let ((__tmp28484
+                                        (let ((__tmp28488
                                                (gx#datum->syntax '#f 'lambda))
-                                              (__tmp28332
-                                               (let ((__tmp28333
-                                                      (let ((__tmp28334
+                                              (__tmp28485
+                                               (let ((__tmp28486
+                                                      (let ((__tmp28487
                                                              (lambda (_g2410324106_
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                               _g2410424109_)
@@ -35,30 +35,30 @@
                          (declare (not safe))
                          (cons _g2410324106_ _g2410424109_)))))
                 (declare (not safe))
-                (foldr1 __tmp28334 '() _L24081_))))
+                (foldr1 __tmp28487 '() _L24081_))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                  (declare (not safe))
-                                                 (cons _L24083_ __tmp28333))))
+                                                 (cons _L24083_ __tmp28486))))
                                           (declare (not safe))
-                                          (cons __tmp28335 __tmp28332))))
+                                          (cons __tmp28488 __tmp28485))))
                                    (declare (not safe))
-                                   (cons __tmp28331 '()))))
+                                   (cons __tmp28484 '()))))
                             (declare (not safe))
-                            (cons _L24084_ __tmp28330))))
+                            (cons _L24084_ __tmp28483))))
                      (declare (not safe))
-                     (cons __tmp28336 __tmp28329))))
+                     (cons __tmp28489 __tmp28482))))
                 (___kont2693826939_
                  (lambda (_L23995_ _L23997_)
-                   (let ((__tmp28339 (gx#datum->syntax '#f 'define-syntax))
-                         (__tmp28337
-                          (let ((__tmp28338
+                   (let ((__tmp28492 (gx#datum->syntax '#f 'define-syntax))
+                         (__tmp28490
+                          (let ((__tmp28491
                                  (let ()
                                    (declare (not safe))
                                    (cons _L23995_ '()))))
                             (declare (not safe))
-                            (cons _L23997_ __tmp28338))))
+                            (cons _L23997_ __tmp28491))))
                      (declare (not safe))
-                     (cons __tmp28339 __tmp28337)))))
+                     (cons __tmp28492 __tmp28490)))))
             (let* ((___match2698626987_
                     (lambda (_e2394623965_
                              _hd2394523969_
@@ -346,37 +346,37 @@
                                                  (##cdr _e2413324184_))))
                                           (if (gx#stx-pair/null?
                                                _tl2413124191_)
-                                              (let ((_g28340_
+                                              (let ((_g28493_
                                                      (gx#syntax-split-splice
                                                       _tl2413124191_
                                                       '0)))
                                                 (begin
-                                                  (let ((_g28341_
+                                                  (let ((_g28494_
                                                          (let ()
                                                            (declare (not safe))
                                                            (if (##values?
-                                                                _g28340_)
+                                                                _g28493_)
                                                                (##vector-length
-                                                                _g28340_)
+                                                                _g28493_)
                                                                1))))
                                                     (if (not (let ()
                                                                (declare
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                          (not safe))
-                       (##fx= _g28341_ 2)))
-                (error "Context expects 2 values" _g28341_)))
+                       (##fx= _g28494_ 2)))
+                (error "Context expects 2 values" _g28494_)))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                   (let ((_target2413424194_
                                                          (let ()
                                                            (declare (not safe))
                                                            (##vector-ref
-                                                            _g28340_
+                                                            _g28493_
                                                             0)))
                                                         (_tl2413624197_
                                                          (let ()
                                                            (declare (not safe))
                                                            (##vector-ref
-                                                            _g28340_
+                                                            _g28493_
                                                             1))))
                                                     (if (gx#stx-null?
                                                          _tl2413624197_)
@@ -403,31 +403,31 @@
                                 (let ((_arg2414224220_
                                        (reverse _arg2414124207_)))
                                   (if (gx#stx-pair/null? _tl2412824181_)
-                                      (let ((_g28342_
+                                      (let ((_g28495_
                                              (gx#syntax-split-splice
                                               _tl2412824181_
                                               '0)))
                                         (begin
-                                          (let ((_g28343_
+                                          (let ((_g28496_
                                                  (let ()
                                                    (declare (not safe))
-                                                   (if (##values? _g28342_)
+                                                   (if (##values? _g28495_)
                                                        (##vector-length
-                                                        _g28342_)
+                                                        _g28495_)
                                                        1))))
                                             (if (not (let ()
                                                        (declare (not safe))
-                                                       (##fx= _g28343_ 2)))
+                                                       (##fx= _g28496_ 2)))
                                                 (error "Context expects 2 values"
-                                                       _g28343_)))
+                                                       _g28496_)))
                                           (let ((_target2414324224_
                                                  (let ()
                                                    (declare (not safe))
-                                                   (##vector-ref _g28342_ 0)))
+                                                   (##vector-ref _g28495_ 0)))
                                                 (_tl2414524227_
                                                  (let ()
                                                    (declare (not safe))
-                                                   (##vector-ref _g28342_ 1))))
+                                                   (##vector-ref _g28495_ 1))))
                                             (if (gx#stx-null? _tl2414524227_)
                                                 (letrec ((_loop2414624230_
                                                           (lambda (_hd2414424234_
@@ -452,7 +452,7 @@
                           ((lambda (_L24254_ _L24256_ _L24257_)
                              (if (and (gx#identifier? _L24257_)
                                       (gx#identifier-list?
-                                       (let ((__tmp28389
+                                       (let ((__tmp28542
                                               (lambda (_g2428124284_
                                                        _g2428224287_)
                                                 (let ()
@@ -460,7 +460,7 @@
                                                   (cons _g2428124284_
                                                         _g2428224287_)))))
                                          (declare (not safe))
-                                         (foldr1 __tmp28389 '() _L24256_))))
+                                         (foldr1 __tmp28542 '() _L24256_))))
                                  (let* ((_g2429024298_
                                          (lambda (_g2429124294_)
                                            (gx#raise-syntax-error
@@ -481,28 +481,28 @@
                                                         (lambda (_g2431824338_)
                                                           (if (gx#stx-pair/null?
                                                                _g2431824338_)
-                                                              (let ((_g28344_
+                                                              (let ((_g28497_
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                              (gx#syntax-split-splice _g2431824338_ '0)))
                         (begin
-                          (let ((_g28345_
+                          (let ((_g28498_
                                  (let ()
                                    (declare (not safe))
-                                   (if (##values? _g28344_)
-                                       (##vector-length _g28344_)
+                                   (if (##values? _g28497_)
+                                       (##vector-length _g28497_)
                                        1))))
                             (if (not (let ()
                                        (declare (not safe))
-                                       (##fx= _g28345_ 2)))
-                                (error "Context expects 2 values" _g28345_)))
+                                       (##fx= _g28498_ 2)))
+                                (error "Context expects 2 values" _g28498_)))
                           (let ((_target2432024341_
                                  (let ()
                                    (declare (not safe))
-                                   (##vector-ref _g28344_ 0)))
+                                   (##vector-ref _g28497_ 0)))
                                 (_tl2432224344_
                                  (let ()
                                    (declare (not safe))
-                                   (##vector-ref _g28344_ 1))))
+                                   (##vector-ref _g28497_ 1))))
                             (if (gx#stx-null? _tl2432224344_)
                                 (letrec ((_loop2432324347_
                                           (lambda (_hd2432124351_
@@ -552,32 +552,32 @@
                                            (let ()
                                              (let ()
                                                (gx#stx-wrap-source
-                                                (let ((__tmp28348
+                                                (let ((__tmp28501
                                                        (gx#datum->syntax
                                                         '#f
                                                         'begin))
-                                                      (__tmp28346
-                                                       (let ((__tmp28347
+                                                      (__tmp28499
+                                                       (let ((__tmp28500
                                                               (let ()
                                                                 (declare
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                           (not safe))
                         (cons _L24403_ '()))))
                  (declare (not safe))
-                 (cons _L24431_ __tmp28347))))
+                 (cons _L24431_ __tmp28500))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                   (declare (not safe))
-                                                  (cons __tmp28348 __tmp28346))
+                                                  (cons __tmp28501 __tmp28499))
                                                 (gx#stx-source _stx24117_)))))
                                          _g2441724428_))))
                                 (_g2441524446_
                                  (gx#stx-wrap-source
-                                  (let ((__tmp28355
+                                  (let ((__tmp28508
                                          (gx#datum->syntax '#f 'def))
-                                        (__tmp28349
-                                         (let ((__tmp28352
-                                                (let ((__tmp28353
-                                                       (let ((__tmp28354
+                                        (__tmp28502
+                                         (let ((__tmp28505
+                                                (let ((__tmp28506
+                                                       (let ((__tmp28507
                                                               (lambda (_g2445124454_
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                                _g2445224457_)
@@ -585,12 +585,12 @@
                           (declare (not safe))
                           (cons _g2445124454_ _g2445224457_)))))
                  (declare (not safe))
-                 (foldr1 __tmp28354 '() _L24256_))))
+                 (foldr1 __tmp28507 '() _L24256_))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                   (declare (not safe))
-                                                  (cons _L24305_ __tmp28353)))
-                                               (__tmp28350
-                                                (let ((__tmp28351
+                                                  (cons _L24305_ __tmp28506)))
+                                               (__tmp28503
+                                                (let ((__tmp28504
                                                        (lambda (_g2444924460_
                                                                 _g2445024463_)
                                                          (let ()
@@ -600,47 +600,47 @@
                          _g2445024463_)))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                   (declare (not safe))
-                                                  (foldr1 __tmp28351
+                                                  (foldr1 __tmp28504
                                                           '()
                                                           _L24254_))))
                                            (declare (not safe))
-                                           (cons __tmp28352 __tmp28350))))
+                                           (cons __tmp28505 __tmp28503))))
                                     (declare (not safe))
-                                    (cons __tmp28355 __tmp28349))
+                                    (cons __tmp28508 __tmp28502))
                                   (gx#stx-source _stx24117_))))))
                           _g2438924400_))))
                  (_g2438724466_
                   (gx#stx-wrap-source
-                   (let ((__tmp28387 (gx#datum->syntax '#f 'defrules))
-                         (__tmp28356
-                          (let ((__tmp28357
-                                 (let ((__tmp28358
-                                        (let ((__tmp28371
-                                               (let ((__tmp28383
-                                                      (let ((__tmp28386
+                   (let ((__tmp28540 (gx#datum->syntax '#f 'defrules))
+                         (__tmp28509
+                          (let ((__tmp28510
+                                 (let ((__tmp28511
+                                        (let ((__tmp28524
+                                               (let ((__tmp28536
+                                                      (let ((__tmp28539
                                                              (gx#datum->syntax
                                                               '#f
                                                               '_))
-                                                            (__tmp28384
-                                                             (let ((__tmp28385
+                                                            (__tmp28537
+                                                             (let ((__tmp28538
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                             (lambda (_g2447524478_ _g2447624481_)
                               (let ()
                                 (declare (not safe))
                                 (cons _g2447524478_ _g2447624481_)))))
                        (declare (not safe))
-                       (foldr1 __tmp28385 '() _L24371_))))
+                       (foldr1 __tmp28538 '() _L24371_))))
                 (declare (not safe))
-                (cons __tmp28386 __tmp28384)))
+                (cons __tmp28539 __tmp28537)))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-                                                     (__tmp28372
-                                                      (let ((__tmp28373
-                                                             (let ((__tmp28376
+                                                     (__tmp28525
+                                                      (let ((__tmp28526
+                                                             (let ((__tmp28529
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                            (let ((__tmp28382 (gx#datum->syntax '#f 'lambda))
-                                  (__tmp28377
-                                   (let ((__tmp28380
-                                          (let ((__tmp28381
+                            (let ((__tmp28535 (gx#datum->syntax '#f 'lambda))
+                                  (__tmp28530
+                                   (let ((__tmp28533
+                                          (let ((__tmp28534
                                                  (lambda (_g2447324484_
                                                           _g2447424487_)
                                                    (let ()
@@ -648,9 +648,9 @@
                                                      (cons _g2447324484_
                                                            _g2447424487_)))))
                                             (declare (not safe))
-                                            (foldr1 __tmp28381 '() _L24256_)))
-                                         (__tmp28378
-                                          (let ((__tmp28379
+                                            (foldr1 __tmp28534 '() _L24256_)))
+                                         (__tmp28531
+                                          (let ((__tmp28532
                                                  (lambda (_g2447124490_
                                                           _g2447224493_)
                                                    (let ()
@@ -658,73 +658,73 @@
                                                      (cons _g2447124490_
                                                            _g2447224493_)))))
                                             (declare (not safe))
-                                            (foldr1 __tmp28379 '() _L24254_))))
+                                            (foldr1 __tmp28532 '() _L24254_))))
                                      (declare (not safe))
-                                     (cons __tmp28380 __tmp28378))))
+                                     (cons __tmp28533 __tmp28531))))
                               (declare (not safe))
-                              (cons __tmp28382 __tmp28377)))
-                           (__tmp28374
-                            (let ((__tmp28375
+                              (cons __tmp28535 __tmp28530)))
+                           (__tmp28527
+                            (let ((__tmp28528
                                    (lambda (_g2446924496_ _g2447024499_)
                                      (let ()
                                        (declare (not safe))
                                        (cons _g2446924496_ _g2447024499_)))))
                               (declare (not safe))
-                              (foldr1 __tmp28375 '() _L24371_))))
+                              (foldr1 __tmp28528 '() _L24371_))))
                        (declare (not safe))
-                       (cons __tmp28376 __tmp28374))))
+                       (cons __tmp28529 __tmp28527))))
                 (declare (not safe))
-                (cons __tmp28373 '()))))
+                (cons __tmp28526 '()))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                  (declare (not safe))
-                                                 (cons __tmp28383 __tmp28372)))
-                                              (__tmp28359
-                                               (let ((__tmp28360
-                                                      (let ((__tmp28370
+                                                 (cons __tmp28536 __tmp28525)))
+                                              (__tmp28512
+                                               (let ((__tmp28513
+                                                      (let ((__tmp28523
                                                              (gx#datum->syntax
                                                               '#f
                                                               'ref))
-                                                            (__tmp28361
-                                                             (let ((__tmp28363
+                                                            (__tmp28514
+                                                             (let ((__tmp28516
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-                            (let ((__tmp28369
+                            (let ((__tmp28522
                                    (gx#datum->syntax '#f 'identifier?))
-                                  (__tmp28364
-                                   (let ((__tmp28365
-                                          (let ((__tmp28368
+                                  (__tmp28517
+                                   (let ((__tmp28518
+                                          (let ((__tmp28521
                                                  (gx#datum->syntax
                                                   '#f
                                                   'syntax))
-                                                (__tmp28366
-                                                 (let ((__tmp28367
+                                                (__tmp28519
+                                                 (let ((__tmp28520
                                                         (gx#datum->syntax
                                                          '#f
                                                          'ref)))
                                                    (declare (not safe))
-                                                   (cons __tmp28367 '()))))
+                                                   (cons __tmp28520 '()))))
                                             (declare (not safe))
-                                            (cons __tmp28368 __tmp28366))))
+                                            (cons __tmp28521 __tmp28519))))
                                      (declare (not safe))
-                                     (cons __tmp28365 '()))))
+                                     (cons __tmp28518 '()))))
                               (declare (not safe))
-                              (cons __tmp28369 __tmp28364)))
-                           (__tmp28362
+                              (cons __tmp28522 __tmp28517)))
+                           (__tmp28515
                             (let () (declare (not safe)) (cons _L24305_ '()))))
                        (declare (not safe))
-                       (cons __tmp28363 __tmp28362))))
+                       (cons __tmp28516 __tmp28515))))
                 (declare (not safe))
-                (cons __tmp28370 __tmp28361))))
+                (cons __tmp28523 __tmp28514))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                  (declare (not safe))
-                                                 (cons __tmp28360 '()))))
+                                                 (cons __tmp28513 '()))))
                                           (declare (not safe))
-                                          (cons __tmp28371 __tmp28359))))
+                                          (cons __tmp28524 __tmp28512))))
                                    (declare (not safe))
-                                   (cons '() __tmp28358))))
+                                   (cons '() __tmp28511))))
                             (declare (not safe))
-                            (cons _L24257_ __tmp28357))))
+                            (cons _L24257_ __tmp28510))))
                      (declare (not safe))
-                     (cons __tmp28387 __tmp28356))
+                     (cons __tmp28540 __tmp28509))
                    (gx#stx-source _stx24117_))))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                    _xarg2432824367_))))))
@@ -734,7 +734,7 @@
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                   (_g2431624502_
                                                    (gx#gentemps
-                                                    (let ((__tmp28388
+                                                    (let ((__tmp28541
                                                            (lambda (_g2450524508_
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                             _g2450624511_)
@@ -742,7 +742,7 @@
                        (declare (not safe))
                        (cons _g2450524508_ _g2450624511_)))))
               (declare (not safe))
-              (foldr1 __tmp28388 '() _L24256_)))))))
+              (foldr1 __tmp28541 '() _L24256_)))))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                             _g2429124302_))))
                                    (_g2428924514_
@@ -780,79 +780,79 @@
                    ___stx2698926990_))))
           (let ((___kont2699226993_
                  (lambda (_L24680_ _L24682_)
-                   (let ((__tmp28407 (gx#datum->syntax '#f 'defrules))
-                         (__tmp28390
-                          (let ((__tmp28391
-                                 (let ((__tmp28392
-                                        (let ((__tmp28393
-                                               (let ((__tmp28406
+                   (let ((__tmp28560 (gx#datum->syntax '#f 'defrules))
+                         (__tmp28543
+                          (let ((__tmp28544
+                                 (let ((__tmp28545
+                                        (let ((__tmp28546
+                                               (let ((__tmp28559
                                                       (gx#datum->syntax
                                                        '#f
                                                        'x))
-                                                     (__tmp28394
-                                                      (let ((__tmp28399
-                                                             (let ((__tmp28405
+                                                     (__tmp28547
+                                                      (let ((__tmp28552
+                                                             (let ((__tmp28558
 ;;<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                             (gx#datum->syntax '#f 'identifier?))
-                           (__tmp28400
-                            (let ((__tmp28401
-                                   (let ((__tmp28404
+                           (__tmp28553
+                            (let ((__tmp28554
+                                   (let ((__tmp28557
                                           (gx#datum->syntax '#f 'syntax))
-                                         (__tmp28402
-                                          (let ((__tmp28403
+                                         (__tmp28555
+                                          (let ((__tmp28556
                                                  (gx#datum->syntax '#f 'x)))
                                             (declare (not safe))
-                                            (cons __tmp28403 '()))))
+                                            (cons __tmp28556 '()))))
                                      (declare (not safe))
-                                     (cons __tmp28404 __tmp28402))))
+                                     (cons __tmp28557 __tmp28555))))
                               (declare (not safe))
-                              (cons __tmp28401 '()))))
+                              (cons __tmp28554 '()))))
                        (declare (not safe))
-                       (cons __tmp28405 __tmp28400)))
-                    (__tmp28395
-                     (let ((__tmp28396
-                            (let ((__tmp28398 (gx#datum->syntax '#f 'quote))
-                                  (__tmp28397
+                       (cons __tmp28558 __tmp28553)))
+                    (__tmp28548
+                     (let ((__tmp28549
+                            (let ((__tmp28551 (gx#datum->syntax '#f 'quote))
+                                  (__tmp28550
                                    (let ()
                                      (declare (not safe))
                                      (cons _L24680_ '()))))
                               (declare (not safe))
-                              (cons __tmp28398 __tmp28397))))
+                              (cons __tmp28551 __tmp28550))))
                        (declare (not safe))
-                       (cons __tmp28396 '()))))
+                       (cons __tmp28549 '()))))
                 (declare (not safe))
-                (cons __tmp28399 __tmp28395))))
+                (cons __tmp28552 __tmp28548))))
 ;;>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
                                                  (declare (not safe))
-                                                 (cons __tmp28406
-                                                       __tmp28394))))
+                                                 (cons __tmp28559
+                                                       __tmp28547))))
                                           (declare (not safe))
-                                          (cons __tmp28393 '()))))
+                                          (cons __tmp28546 '()))))
                                    (declare (not safe))
-                                   (cons '() __tmp28392))))
+                                   (cons '() __tmp28545))))
                             (declare (not safe))
-                            (cons _L24682_ __tmp28391))))
+                            (cons _L24682_ __tmp28544))))
                      (declare (not safe))
-                     (cons __tmp28407 __tmp28390))))
+                     (cons __tmp28560 __tmp28543))))
                 (___kont2699426995_
                  (lambda (_L24603_ _L24605_ _L24606_)
-                   (let ((__tmp28408
-                          (let ((__tmp28409
-                                 (let ((__tmp28410
-                                        (let ((__tmp28412
+                   (let ((__tmp28561
+                          (let ((__tmp28562
+                                 (let ((__tmp28563
+                                        (let ((__tmp28565
                                                (gx#datum->syntax '#f 'quote))
-                                              (__tmp28411
+                                              (__tmp28564
                                                (let ()
                                                  (declare (not safe))
                                                  (cons _L24603_ '()))))
                                           (declare (not safe))
-                                          (cons __tmp28412 __tmp28411))))
+                                          (cons __tmp28565 __tmp28564))))
                                    (declare (not safe))
-                                   (cons __tmp28410 '()))))
+                                   (cons __tmp28563 '()))))
                             (declare (not safe))
-                            (cons _L24605_ __tmp28409))))
+                            (cons _L24605_ __tmp28562))))
                      (declare (not safe))
-                     (cons _L24606_ __tmp28408)))))
+                     (cons _L24606_ __tmp28561)))))
             (let* ((___match2705427055_
                     (lambda (_e2455424573_
                              _hd2455324577_
@@ -943,7 +943,7 @@
                                               (if (gx#identifier?
                                                    _hd2454424664_)
                                                   (if (gx#free-identifier=?
-                                                       |gerbil/core/sugar~Sugar-3[1]#_g28413_|
+                                                       |gerbil/core/sugar~Sugar-3[1]#_g28566_|
                                                        _hd2454424664_)
                                                       (if (gx#stx-pair?
                                                            _tl2454324667_)

--- a/src/bootstrap/gerbil/expander/common~0.scm
+++ b/src/bootstrap/gerbil/expander/common~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/expander/common::timestamp 1710943497)
+  (define gerbil/expander/common::timestamp 1710954836)
   (begin
     (define gx#AST::t
       (let ((__tmp81470 (list))

--- a/src/bootstrap/gerbil/expander/compile~0.scm
+++ b/src/bootstrap/gerbil/expander/compile~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/expander/compile::timestamp 1710943498)
+  (define gerbil/expander/compile::timestamp 1710954836)
   (begin
     (declare (not safe))
     (define gx#core-compile-top-syntax

--- a/src/bootstrap/gerbil/expander/core~0.scm
+++ b/src/bootstrap/gerbil/expander/core~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/expander/core::timestamp 1710943497)
+  (define gerbil/expander/core::timestamp 1710954836)
   (begin
     (declare (not safe))
     (define gx#current-expander-context (make-parameter '#f))

--- a/src/bootstrap/gerbil/expander/init~0.scm
+++ b/src/bootstrap/gerbil/expander/init~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/expander/init::timestamp 1710943498)
+  (define gerbil/expander/init::timestamp 1710954837)
   (begin
     (gx#current-expander-context
      (let ((__obj98936

--- a/src/bootstrap/gerbil/expander/module.ssxi.ss
+++ b/src/bootstrap/gerbil/expander/module.ssxi.ss
@@ -206,8 +206,10 @@ package: gerbil/expander
            #f
            #f
            #f
-           ((apply-import-expander . gx#import-expander::apply-import-expander)
-            (:init! . gx#import-expander:::init!))))
+           ((:init! . gx#import-expander:::init!)
+            (apply-import-expander
+             .
+             gx#import-expander::apply-import-expander))))
   (declare-type gx#import-expander? (@predicate gx#import-expander::t))
   (declare-type gx#make-import-expander (@constructor gx#import-expander::t))
   (declare-type

--- a/src/bootstrap/gerbil/expander/module~0.scm
+++ b/src/bootstrap/gerbil/expander/module~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/expander/module::timestamp 1710943498)
+  (define gerbil/expander/module::timestamp 1710954836)
   (begin
     (declare (not safe))
     (define gx#__module-registry (make-hash-table))

--- a/src/bootstrap/gerbil/expander/root~0.scm
+++ b/src/bootstrap/gerbil/expander/root~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/expander/root::timestamp 1710943498)
+  (define gerbil/expander/root::timestamp 1710954837)
   (begin
     (declare (not safe))
     (define gx#*core-syntax-expanders*
@@ -328,17 +328,18 @@
                   _g97274_))))))
     (define gx#root-context:::init!::specialize
       (lambda (__klass97229 __method-table97230)
-        (let ((__bind-core-features!97231
+        (let ((__bind-core-macro-expanders!97231
                (make-promise
                 (lambda ()
                   (let ((__method97234
                          (symbolic-table-ref
                           __method-table97230
-                          'bind-core-features!
+                          'bind-core-macro-expanders!
                           '#f)))
                     (if __method97234
                         __method97234
-                        (error '"Missing method" 'bind-core-features!))))))
+                        (error '"Missing method"
+                               'bind-core-macro-expanders!))))))
               (__bind-core-syntax-expanders!97232
                (make-promise
                 (lambda ()
@@ -351,18 +352,17 @@
                         __method97235
                         (error '"Missing method"
                                'bind-core-syntax-expanders!))))))
-              (__bind-core-macro-expanders!97233
+              (__bind-core-features!97233
                (make-promise
                 (lambda ()
                   (let ((__method97236
                          (symbolic-table-ref
                           __method-table97230
-                          'bind-core-macro-expanders!
+                          'bind-core-features!
                           '#f)))
                     (if __method97236
                         __method97236
-                        (error '"Missing method"
-                               'bind-core-macro-expanders!)))))))
+                        (error '"Missing method" 'bind-core-features!)))))))
           (let ((_opt-lambda9721597220_
                  (lambda (_self97217_ _bind?97218_)
                    (if (##fx< '2 (##structure-length _self97217_))
@@ -387,9 +387,9 @@
                        (begin
                          ((force __bind-core-syntax-expanders!97232)
                           _self97217_)
-                         ((force __bind-core-macro-expanders!97233)
+                         ((force __bind-core-macro-expanders!97231)
                           _self97217_)
-                         ((force __bind-core-features!97231) _self97217_))
+                         ((force __bind-core-features!97233) _self97217_))
                        '#!void))))
             (lambda _g97276_
               (let ((_g97275_ (##length _g97276_)))

--- a/src/bootstrap/gerbil/expander/stxcase~0.scm
+++ b/src/bootstrap/gerbil/expander/stxcase~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/expander/stxcase::timestamp 1710943498)
+  (define gerbil/expander/stxcase::timestamp 1710954837)
   (begin
     (define gx#syntax-pattern::t
       (let ((__tmp98634 (list gx#expander::t))

--- a/src/bootstrap/gerbil/expander/stx~0.scm
+++ b/src/bootstrap/gerbil/expander/stx~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/expander/stx::timestamp 1710943497)
+  (define gerbil/expander/stx::timestamp 1710954836)
   (begin
     (declare (not safe))
     (define gx#identifier-wrap::t

--- a/src/bootstrap/gerbil/expander/top~0.scm
+++ b/src/bootstrap/gerbil/expander/top~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/expander/top::timestamp 1710943497)
+  (define gerbil/expander/top::timestamp 1710954836)
   (begin
     (declare (not safe))
     (define gx#core-expand-begin%

--- a/src/bootstrap/gerbil/runtime/c3~0.scm
+++ b/src/bootstrap/gerbil/runtime/c3~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/c3::timestamp 1710943496)
+  (define gerbil/runtime/c3::timestamp 1710954835)
   (begin
     (define c4-linearize__%
       (lambda (_g62595_

--- a/src/bootstrap/gerbil/runtime/control~0.scm
+++ b/src/bootstrap/gerbil/runtime/control~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/control::timestamp 1710943496)
+  (define gerbil/runtime/control::timestamp 1710954835)
   (begin
     (define make-promise
       (lambda (_thunk62139_)

--- a/src/bootstrap/gerbil/runtime/error~0.scm
+++ b/src/bootstrap/gerbil/runtime/error~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/error::timestamp 1710943497)
+  (define gerbil/runtime/error::timestamp 1710954835)
   (begin
     (define Exception::t
       (let ((__tmp68183 (list)))
@@ -538,26 +538,26 @@
             (##write-string __tmp68198 _port67926_)))))
     (define Error::display-exception::specialize
       (lambda (__klass68157 __method-table68158)
-        (let ((__continuation68159
+        (let ((__message68159
                (let ((__slot68163
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass68157 'continuation))))
+                        (class-slot-offset __klass68157 'message))))
                  (if __slot68163
                      __slot68163
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'continuation)))))
-              (__message68160
+                       (error '"Unknown slot" 'message)))))
+              (__where68160
                (let ((__slot68164
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass68157 'message))))
+                        (class-slot-offset __klass68157 'where))))
                  (if __slot68164
                      __slot68164
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'message)))))
+                       (error '"Unknown slot" 'where)))))
               (__irritants68161
                (let ((__slot68165
                       (let ()
@@ -568,16 +568,16 @@
                      (let ()
                        (declare (not safe))
                        (error '"Unknown slot" 'irritants)))))
-              (__where68162
+              (__continuation68162
                (let ((__slot68166
                       (let ()
                         (declare (not safe))
-                        (class-slot-offset __klass68157 'where))))
+                        (class-slot-offset __klass68157 'continuation))))
                  (if __slot68166
                      __slot68166
                      (let ()
                        (declare (not safe))
-                       (error '"Unknown slot" 'where))))))
+                       (error '"Unknown slot" 'continuation))))))
           (lambda (_self67925_ _port67926_)
             (let ((_tmp-port67928_ (open-output-string))
                   (_display-error-newline67929_
@@ -592,7 +592,7 @@
                                 (declare (not safe))
                                 (##unchecked-structure-ref
                                  _self67925_
-                                 __where68162
+                                 __where68160
                                  __klass68157
                                  '#f))))
                          (if _$e67932_ (display _$e67932_) (display '"?")))
@@ -607,7 +607,7 @@
                                 (declare (not safe))
                                 (##unchecked-structure-ref
                                  _self67925_
-                                 __message68160
+                                 __message68159
                                  __klass68157
                                  '#f))))
                          (declare (not safe))
@@ -641,7 +641,7 @@
                                     (declare (not safe))
                                     (##unchecked-structure-ref
                                      _self67925_
-                                     __continuation68159
+                                     __continuation68162
                                      __klass68157
                                      '#f))))
                              (if _cont6793867940_

--- a/src/bootstrap/gerbil/runtime/eval~0.scm
+++ b/src/bootstrap/gerbil/runtime/eval~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/eval::timestamp 1710943497)
+  (define gerbil/runtime/eval::timestamp 1710954836)
   (begin
     (define __syntax::t
       (let ((__tmp79312 (list))

--- a/src/bootstrap/gerbil/runtime/gambit~0.scm
+++ b/src/bootstrap/gerbil/runtime/gambit~0.scm
@@ -1,2 +1,2 @@
 (declare (block) (standard-bindings) (extended-bindings))
-(begin (define gerbil/runtime/gambit::timestamp 1710943496) '#!void)
+(begin (define gerbil/runtime/gambit::timestamp 1710954835) '#!void)

--- a/src/bootstrap/gerbil/runtime/hash.ssxi.ss
+++ b/src/bootstrap/gerbil/runtime/hash.ssxi.ss
@@ -213,14 +213,14 @@ package: gerbil/runtime
            #t
            #f
            #f
-           ((copy . _locked-hash-table::copy71025_)
-            (clear! . _locked-hash-table::clear!71027_)
-            (for-each . _locked-hash-table::for-each71021_)
+           ((update! . _locked-hash-table::update!71017_)
             (set! . _locked-hash-table::set!71015_)
+            (for-each . _locked-hash-table::for-each71021_)
+            (copy . _locked-hash-table::copy71025_)
+            (ref . _locked-hash-table::ref71013_)
+            (clear! . _locked-hash-table::clear!71027_)
             (delete! . _locked-hash-table::delete!71019_)
-            (length . _locked-hash-table::length71023_)
-            (update! . _locked-hash-table::update!71017_)
-            (ref . _locked-hash-table::ref71013_))))
+            (length . _locked-hash-table::length71023_))))
   (declare-type locked-hash-table? (@predicate locked-hash-table::t))
   (declare-type make-locked-hash-table (@constructor locked-hash-table::t))
   (declare-type
@@ -259,14 +259,14 @@ package: gerbil/runtime
            #t
            #f
            #f
-           ((copy . _checked-hash-table::copy71317_)
-            (clear! . _checked-hash-table::clear!71319_)
-            (for-each . _checked-hash-table::for-each71313_)
+           ((update! . _checked-hash-table::update!71309_)
             (set! . _checked-hash-table::set!71307_)
+            (for-each . _checked-hash-table::for-each71313_)
+            (copy . _checked-hash-table::copy71317_)
+            (ref . _checked-hash-table::ref71305_)
+            (clear! . _checked-hash-table::clear!71319_)
             (delete! . _checked-hash-table::delete!71311_)
-            (length . _checked-hash-table::length71315_)
-            (update! . _checked-hash-table::update!71309_)
-            (ref . _checked-hash-table::ref71305_))))
+            (length . _checked-hash-table::length71315_))))
   (declare-type checked-hash-table? (@predicate checked-hash-table::t))
   (declare-type make-checked-hash-table (@constructor checked-hash-table::t))
   (declare-type

--- a/src/bootstrap/gerbil/runtime/hash~0.scm
+++ b/src/bootstrap/gerbil/runtime/hash~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/hash::timestamp 1710943497)
+  (define gerbil/runtime/hash::timestamp 1710954836)
   (begin
     (define UnboundKeyError::t
       (let ((__tmp74305 (list Error::t)))

--- a/src/bootstrap/gerbil/runtime/init~0.scm
+++ b/src/bootstrap/gerbil/runtime/init~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/init::timestamp 1710943497)
+  (define gerbil/runtime/init::timestamp 1710954836)
   (begin
     (define __scheme-source (make-parameter '#f))
     (define __load-gxi

--- a/src/bootstrap/gerbil/runtime/interface~0.scm
+++ b/src/bootstrap/gerbil/runtime/interface~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/interface::timestamp 1710943497)
+  (define gerbil/runtime/interface::timestamp 1710954836)
   (begin
     (define CastError::t
       (let ((__tmp69915 (list Error::t)))

--- a/src/bootstrap/gerbil/runtime/loader~0.scm
+++ b/src/bootstrap/gerbil/runtime/loader~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/loader::timestamp 1710943497)
+  (define gerbil/runtime/loader::timestamp 1710954836)
   (begin
     (define __modules (let () (declare (not safe)) (make-hash-table)))
     (define __load-path '())

--- a/src/bootstrap/gerbil/runtime/mop-system-classes~0.scm
+++ b/src/bootstrap/gerbil/runtime/mop-system-classes~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/mop-system-classes::timestamp 1710943497)
+  (define gerbil/runtime/mop-system-classes::timestamp 1710954835)
   (begin
     (declare
       (not optimize-dead-definitions

--- a/src/bootstrap/gerbil/runtime/mop~0.scm
+++ b/src/bootstrap/gerbil/runtime/mop~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/mop::timestamp 1710943496)
+  (define gerbil/runtime/mop::timestamp 1710954835)
   (begin
     (define type-flag-opaque '1)
     (define type-flag-extensible '2)
@@ -2535,12 +2535,14 @@
                                  _klass64587_
                                  'method:
                                  _id64588_))
-                        (let ()
-                          (declare (not safe))
-                          (symbolic-table-set!
-                           _ht64598_
-                           _id64588_
-                           _proc64589_))))))
+                        (begin
+                          (let ()
+                            (declare (not safe))
+                            (symbolic-table-set!
+                             _ht64598_
+                             _id64588_
+                             _proc64589_))
+                          '#!void)))))
           (if (let () (declare (not safe)) (procedure? _proc64589_))
               '#!void
               (let ()

--- a/src/bootstrap/gerbil/runtime/repl~0.scm
+++ b/src/bootstrap/gerbil/runtime/repl~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/repl::timestamp 1710943497)
+  (define gerbil/runtime/repl::timestamp 1710954836)
   (define replx
     (lambda ()
       (letrec ((_write-reason79843_

--- a/src/bootstrap/gerbil/runtime/syntax~0.scm
+++ b/src/bootstrap/gerbil/runtime/syntax~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/syntax::timestamp 1710943497)
+  (define gerbil/runtime/syntax::timestamp 1710954836)
   (begin
     (declare (not safe))
     (define SyntaxError::t

--- a/src/bootstrap/gerbil/runtime/system~0.scm
+++ b/src/bootstrap/gerbil/runtime/system~0.scm
@@ -1,8 +1,8 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/system::timestamp 1710943496)
+  (define gerbil/runtime/system::timestamp 1710954835)
   (begin
-    (define gerbil-version-string (lambda () '"v0.18.1-72-gb280d037"))
+    (define gerbil-version-string (lambda () '"v0.18.1-76-g8bcf6230"))
     (define gerbil-system-manifest
       (let ((__tmp62251
              (let ((__tmp62252

--- a/src/bootstrap/gerbil/runtime/table~0.scm
+++ b/src/bootstrap/gerbil/runtime/table~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/table::timestamp 1710943496)
+  (define gerbil/runtime/table::timestamp 1710954835)
   (begin
     (declare (not safe))
     (define __table::t.id 'gerbil#__table::t)

--- a/src/bootstrap/gerbil/runtime/thread~0.scm
+++ b/src/bootstrap/gerbil/runtime/thread~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/thread::timestamp 1710943497)
+  (define gerbil/runtime/thread::timestamp 1710954836)
   (begin
     (define spawn
       (lambda (_f74914_ . _args74915_)

--- a/src/bootstrap/gerbil/runtime/util~0.scm
+++ b/src/bootstrap/gerbil/runtime/util~0.scm
@@ -1,6 +1,6 @@
 (declare (block) (standard-bindings) (extended-bindings))
 (begin
-  (define gerbil/runtime/util::timestamp 1710943496)
+  (define gerbil/runtime/util::timestamp 1710954835)
   (begin
     (define displayln
       (lambda _args57303_

--- a/src/bootstrap/gerbil/runtime~0.scm
+++ b/src/bootstrap/gerbil/runtime~0.scm
@@ -1,2 +1,2 @@
 (declare (block) (standard-bindings) (extended-bindings))
-(begin (define gerbil/runtime::timestamp 1710943497) '#!void)
+(begin (define gerbil/runtime::timestamp 1710954836) '#!void)

--- a/src/gerbil/runtime/mop.ss
+++ b/src/gerbil/runtime/mop.ss
@@ -845,7 +845,9 @@ namespace: #f
   (def (bind! ht)
     (if (and (not rebind?) (symbolic-table-ref ht id #f))
       (error "method already bound" class: klass method: id)
-      (symbolic-table-set! ht id proc)))
+      (begin
+        (symbolic-table-set! ht id proc)
+        (void))))
 
   (unless (procedure? proc)
     (error "bad method; expected procedure" proc))


### PR DESCRIPTION
Yikes:
```
(defmethod {colorize Point3D}
  (lambda (self)
    (ColoredPoint3D x: (@ self x)
                    y: (@ self y)
                    z: (@ self z)
                    r: 0 g: 0 b: 0)))
#(#<unknown>
  #<unknown>
  #<unknown>
  #<unknown>
  colorize
  #<procedure #14 Point3D::colorize>
  #<unknown>
  #<unknown>
  #<unknown>
  #<unknown>
  #<unknown>
  #<unknown>
  #<unknown>
  #<unknown>
  #<unknown>
  #<unknown>)
```