### PR TITLE
os-error: replace #u8() by '<u8vector>' in irritants

### DIFF
--- a/src/std/net/httpd/handler.ss
+++ b/src/std/net/httpd/handler.ss
@@ -135,8 +135,14 @@
     (try
      (loop)
      (catch (os-error? e)
-       ;; only keep the failed primitive.
-       (set-cdr! (error-irritants e) '())
+       ;; replace all #u8() with <u8vector>
+       (slot-set! e 'irritants
+                  (foldr (lambda (item acc)
+                           (if (u8vector? item)
+                             (cons "<u8vector>" acc)
+                             (cons item acc)))
+                         '()
+                         (error-irritants e)))
        (errorf "unhandled exception: ~a" e)
        (raise e))
      (catch (e)

--- a/src/std/net/httpd/handler.ss
+++ b/src/std/net/httpd/handler.ss
@@ -137,12 +137,8 @@
      (catch (os-error? e)
        ;; replace all #u8() with <u8vector>
        (slot-set! e 'irritants
-                  (foldr (lambda (item acc)
-                           (if (u8vector? item)
-                             (cons "<u8vector>" acc)
-                             (cons item acc)))
-                         '()
-                         (error-irritants e)))
+                  (map (lambda (x) (if (u8vector? x) '<u8vector> x))
+                       (error-irritants e)))
        (errorf "unhandled exception: ~a" e)
        (raise e))
      (catch (e)


### PR DESCRIPTION
replace #u8vector by <u8vector> in irritants upon os-error in http handler