### PR TITLE
call iter on the iterable when filtering

### DIFF
--- a/src/std/iter-test.ss
+++ b/src/std/iter-test.ss
@@ -159,6 +159,11 @@
           (cons (cons x y) r)))
       (check (test-filter-when4) => '((3 . d) (1 . b)))
 
+      (def (test-filter-when5)
+        (for/collect ((x '(1 2 3 4) when (odd? x)))
+          x))
+      (check (test-filter-when5) => '(1 3))
+
       (def (test-for-when5)
         (for ((x (in-range 5)) when (odd? x))
           (displayln x)))

--- a/src/std/iter.ss
+++ b/src/std/iter.ss
@@ -239,10 +239,10 @@
    (cond
     ((&iterator-fini it) => (cut <> it)))))
 
-(def (iter-filter (pred : :procedure) (it : iterator))
+(def (iter-filter (pred : :procedure) iterable)
   => iterator
   (def (iterate)
-    (for (val it)
+    (for (val (iter iterable))
       (when (pred val)
         (yield val))))
   (iter-coroutine iterate))


### PR DESCRIPTION
the various iteration macros (e.g. for) accept any object with the :iter generic defined; however when a filter clause was present iter wasnt called

fixes #1211 