### PR TITLE
Doom emacs package instructions

### DIFF
--- a/doc/guide/emacs.md
+++ b/doc/guide/emacs.md
@@ -57,6 +57,8 @@ To add Gambit and Gerbil modes, go to the bottom of `package.el` and add the fol
 Save the file with `:w` and close the buffer with `SPC b d`.
 You should arrive back at the Doom Emacs splash screen.
 
+In order to fetch and install these packaged you must first exit doom emacs using `SPC q K` and then run `doom sync`.
+
 Let's create a convenient key sequence that opens a Gerbil REPL in a nice window layout.
 Type `SPC f P` again and choose `config.el`.
 This opens the private configuration file for your Doom Emacs installation.


### PR DESCRIPTION
Added a bit of help for actually installing the packages for doom emacs. I had a hard time figuring out how to actually get the packages working so I added a little bit of clarification that you must run `doom sync` from the command line outside of doom emacs.