### PR TITLE
Prevent invalid URL fragments

### DIFF
--- a/doc/.vuepress/config.js
+++ b/doc/.vuepress/config.js
@@ -291,5 +291,42 @@ module.exports = {
       },
     ],
   },
+  markdown: {
+      slugify: function(str) {
+          if (!/^[a-zA-Z][\-0-9a-zA-Z]$/.test(str) // not basic dash + alphanum
+              || /^-/.test(str) // or starts with dash
+              || /-$/.test(str) // or ends with dash
+              || /--/.test(str) // or has multiple dashes in a row
+             ) {
+              return str
+                  .replace(/^\-\-+/g, 'dashes-')
+                  .replace(/\-\-+$/g, '-dashes')
+                  .replace(/\-\-+/g, '-dashes-')
+                  .replace(/^\-/g, 'dash-')
+                  .replace(/\-$/g, '-dash')
+                  .replace(/([a-zA-Z0-9])\->([a-zA-Z0-9])/g, '$1-to-$2')
+                  .replace(/([a-zA-Z0-9])<\-([a-zA-Z0-9])/g, '$1-from-$2')
+                  .replace(/\$/g, '-dollar-')
+                  .replace(/\//g, '-slash-')
+                  .replace(/:/g, '-colon-')
+                  .replace(/~/g, '-tilde-')
+                  .replace(/=/g, '-eq-')
+                  .replace(/@/g, '-at-')
+                  .replace(/!/g, '-bang-')
+                  .replace(/\+/g, '-plus-')
+                  .replace(/</g, '-gt-')
+                  .replace(/>/g, '-lt-')
+                  .replace(/\?/g, '-qm-')
+                  .replace(/\*/g, '-star-')
+                  .replace(/\-{2,}/g, '-')
+                  .replace(/^\-+|\-+$/g, '')
+                  .replace(/[^-a-zA-Z0-9]/g, '_')
+                  .replace(/\_{2,}/g, '_')
+                  .replace(/^(\d)/, '_$1')
+                  .toLowerCase();
+          }
+          return str.toLowerCase(); // Good as is
+      }
+  },
   current_version: 'v0.12'
 }


### PR DESCRIPTION
Currently sidebar and header links are sometimes empty because of VuePress's slugify rules.  When the URL fragment is empty, the page has a tendency to jump around while viewing it.  For example "->" on
https://cons.io/reference/std/actor.html exhibits this behavior.  This makes viewing the docs occasionally painful, as the page may scroll to the top while viewing it.

While fixing the issue, we might as well have nicer links also, so some work has been done to make common characters and patterns have more descriptive link names.  For example:

* "->" becomes "to"
* "!" becomes "bang"
* "--..." becomes "dashes"