### PR TITLE
Fix freebsd builds for missing openpty

### DIFF
--- a/src/build/build-bach.ss
+++ b/src/build/build-bach.ss
@@ -24,6 +24,8 @@
   (path-expand "lib" (getenv "GERBIL_PREFIX")))
 
 (cond-expand
+ (freebsd
+  (def default-ld-options "-lutil"))
  (netbsd
   (def default-ld-options ["-lm"]))
  (else

--- a/src/build/build-bach.ss
+++ b/src/build/build-bach.ss
@@ -25,7 +25,7 @@
 
 (cond-expand
  (freebsd
-  (def default-ld-options "-lutil"))
+  (def default-ld-options ["-lutil" "-lm"]))
  (netbsd
   (def default-ld-options ["-lm"]))
  (else

--- a/src/build/build-libgerbil.ss
+++ b/src/build/build-libgerbil.ss
@@ -21,6 +21,8 @@
 (def default-gerbil-ar "ar")
 
 (cond-expand
+ (freebsd
+  (def default-ld-options "-lutil"))
  (netbsd
   (def default-ld-options "-lm"))
  (else


### PR DESCRIPTION
Compilation was breaking due to undefined 'openpty' for both build-libgerbil.ss and build-bach.ss.
Back required -lm as well.