### PR TITLE
improve when/unless error reporting

### DIFF
--- a/src/gerbil/core/sugar.ss
+++ b/src/gerbil/core/sugar.ss
@@ -134,12 +134,12 @@ package: gerbil/core
      (if test (let () body ...) (recur . rest))))
 
   (defrules when ()
-    ((_ test expr ...)
-     (if test (begin expr ...) #!void)))
+    ((_ test expr rest ...)
+     (if test (begin expr rest ...) #!void)))
 
   (defrules unless ()
-    ((_ test expr ...)
-     (if test #!void (begin expr ...))))
+    ((_ test expr rest ...)
+     (if test #!void (begin expr rest ...))))
 
   (defsyntax% (syntax-error stx)
     (syntax-case stx ()


### PR DESCRIPTION
Enforce the at least one expression in the body constraint, so that error reporting is understandable.