### PR TITLE
In `serve-json-rpc`, populate `internal-error` with exception

### DIFF
--- a/src/std/net/json-rpc.ss
+++ b/src/std/net/json-rpc.ss
@@ -302,7 +302,7 @@
      ;; Use hash so only one of result: or error: shall be printed
      (def result (processor method params))
      (if notification? (void) (hash ("jsonrpc" jsonrpc) ("id" id) ("result" result)))
-     (catch (e) (return-error (if (json-rpc-error? e) e (internal-error)))))))
+     (catch (e) (return-error (if (json-rpc-error? e) e (internal-error e)))))))
 
 (def (json-rpc-handler/response res log request-json response-json)
   (let/cc return

--- a/src/std/net/json-rpc.ss
+++ b/src/std/net/json-rpc.ss
@@ -302,7 +302,7 @@
      ;; Use hash so only one of result: or error: shall be printed
      (def result (processor method params))
      (if notification? (void) (hash ("jsonrpc" jsonrpc) ("id" id) ("result" result)))
-     (catch (e) (return-error (if (json-rpc-error? e) e (internal-error e)))))))
+     (catch (e) (return-error (if (json-rpc-error? e) e (internal-error (error-message e))))))))
 
 (def (json-rpc-handler/response res log request-json response-json)
   (let/cc return


### PR DESCRIPTION
A 2-char patch.. `json-rpc`s `internal-error` can take an optional (default void) `e` for the error/exception object. Its one call in `json-rpc` does have an `e` in scope that wasn't passed but probably should be. Hence this patch!