### PR TITLE
use current-compile-output-dir for intermediate compilation objects

### DIFF
--- a/src/gerbil/compiler/driver.ss
+++ b/src/gerbil/compiler/driver.ss
@@ -81,11 +81,25 @@ namespace: gxc
 (def (delete-directory* dir)
   (delete-file-or-directory dir #t))
 
+(def compile-output-dir
+  (let (path-separator "/")
+    (lambda (output)
+      (let* ((output-prefix (current-compile-output-dir))
+             (output-prefix (and output-prefix (path-normalize output-prefix))))
+        (if (and output output-prefix (not (string-prefix? output-prefix output)))
+          (let* ((output-path (path-expand (if (string-prefix? path-separator output)
+                                             (string-append "." output) output)
+                                           output-prefix))
+                 (output-dir (path-directory output-path)))
+            (create-directory* output-dir)
+            output-path)
+          output)))))
+
 (def (compile-module srcpath (opts []))
   (unless (string? srcpath)
     (raise-compile-error "Invalid module source path" srcpath))
 
-  (let ((outdir      (pgetq output-dir: opts))
+  (let ((outdir      (compile-output-dir (pgetq output-dir: opts)))
         (invoke-gsc? (pgetq invoke-gsc: opts))
         (gsc-options (pgetq gsc-options: opts))
         (keep-scm?   (pgetq keep-scm: opts))
@@ -117,7 +131,7 @@ namespace: gxc
   (unless (string? srcpath)
     (raise-compile-error "Invalid module source path" srcpath))
 
-  (let ((outdir      (pgetq output-dir: opts))
+  (let ((outdir      (compile-output-dir (pgetq output-dir: opts)))
         (invoke-gsc? (pgetq invoke-gsc: opts))
         (gsc-options (pgetq gsc-options: opts))
         (keep-scm?   (pgetq keep-scm: opts))
@@ -205,35 +219,39 @@ namespace: gxc
         (else (reverse! result)))))
 
   (def (compile-stub output-scm output-bin)
-    (let* ((gerbil-home      (getenv "GERBIL_BUILD_PREFIX" (gerbil-home)))
-           (gerbil-libdir    (path-expand "lib" gerbil-home))
+    (let* ((gerbil-home (getenv "GERBIL_BUILD_PREFIX" (gerbil-home)))
+           (gerbil-libdir (path-expand "lib" gerbil-home))
            (gerbil-staticdir (path-expand "static" gerbil-libdir))
-           (deps             (find-runtime-module-deps ctx))
-           (libgerbil-deps   (filter libgerbil-module? deps))
-           (libgerbil-scm    (map find-static-module-file libgerbil-deps))
-           (libgerbil-scm    (fold-libgerbil-runtime-scm gerbil-staticdir libgerbil-scm))
-           (libgerbil-c      (map (cut replace-extension <> ".c") libgerbil-scm))
-           (libgerbil-o      (map (cut replace-extension <> ".o") libgerbil-scm))
-           (src-deps         (filter userlib-module? deps))
-           (src-deps-scm     (map find-static-module-file src-deps))
-           (src-deps-scm     (filter not-file-empty? src-deps-scm))
-           (src-deps-scm     (map path-expand src-deps-scm))
-           (src-deps-c       (map (cut replace-extension <> ".c") src-deps-scm))
-           (src-deps-o       (map (cut replace-extension <> ".o") src-deps-scm))
-           (src-bin-scm      (find-static-module-file ctx))
-           (src-bin-scm      (path-expand src-bin-scm))
-           (src-bin-c        (replace-extension src-bin-scm ".c"))
-           (src-bin-o        (replace-extension src-bin-scm ".o"))
-           (output-bin       (path-expand output-bin))
-           (output-scm       (path-expand output-scm))
-           (output-c         (replace-extension output-scm ".c"))
-           (output-o         (replace-extension output-scm ".o"))
-           (output_-c        (replace-extension output-scm "_.c"))
-           (output_-o        (replace-extension output-scm "_.o"))
-           (gsc-link-opts    (gsc-link-options))
-           (gsc-cc-opts      (gsc-cc-options static: #t))
-           (gsc-static-opts  (gsc-static-include-options gerbil-staticdir))
-           (output-ld-opts   (gcc-ld-options))
+           (deps (find-runtime-module-deps ctx))
+           (libgerbil-deps (filter libgerbil-module? deps))
+           (libgerbil-scm (map find-static-module-file libgerbil-deps))
+           (libgerbil-scm (fold-libgerbil-runtime-scm gerbil-staticdir libgerbil-scm))
+           (libgerbil-c (map (cut replace-extension <> ".c") libgerbil-scm))
+           (libgerbil-o (map (cut replace-extension <> ".o") libgerbil-scm))
+           (src-deps (filter userlib-module? deps))
+           (src-deps-scm (map find-static-module-file src-deps))
+           (src-deps-scm (filter not-file-empty? src-deps-scm))
+           (src-deps-scm (map path-expand src-deps-scm))
+           (src-deps-o (map (cut replace-extension <> ".o") src-deps-scm))
+           (src-deps-o (map compile-output-dir src-deps-o))
+           (src-bin-scm (find-static-module-file ctx))
+           (src-bin-scm (path-expand src-bin-scm))
+           (src-bin-o (replace-extension src-bin-scm ".o"))
+           (src-deps-c (map (lambda (scm-path)
+                              (compile-output-dir
+                               (replace-extension scm-path ".c")))
+                            src-deps-scm))
+           (src-bin-c (replace-extension src-bin-scm ".c"))
+           (output-bin (path-expand output-bin))
+           (output-scm (path-expand output-scm))
+           (output-c (replace-extension output-scm ".c"))
+           (output-o (replace-extension output-scm ".o"))
+           (output_-c (replace-extension output-scm "_.c"))
+           (output_-o (replace-extension output-scm "_.o"))
+           (gsc-link-opts (gsc-link-options))
+           (gsc-cc-opts (gsc-cc-options static: #t))
+           (gsc-static-opts (gsc-static-include-options gerbil-staticdir))
+           (output-ld-opts (gcc-ld-options))
            (libgerbil-ld-opts (get-libgerbil-ld-opts gerbil-libdir))
            (rpath (gerbil-rpath gerbil-libdir))
            (builtin-modules
@@ -242,36 +260,35 @@ namespace: gxc
                      (map (lambda (mod) (symbol->string (expander-context-id mod)))
                           (cons ctx deps))))))
 
-      (def (compile-obj scm-path c-path)
-        (let (o-path (replace-extension c-path ".o"))
-          (let* ((lock (string-append o-path ".lock"))
-                 (locked #f)
-                 (unlock
-                  (lambda ()
-                    (close-port locked)
-                    (delete-file lock))))
-            (let retry ()
-              (if (file-exists? lock)
-                (begin
-                  (thread-sleep! .01)
-                  (retry))
-                (begin
-                  (set! locked
-                    (with-catch false (cut open-file [path: lock create: #t])))
-                  (unless locked
-                    (retry)))))
+      (def (compile-obj scm-path c-path o-path)
+        (let* ((lock (string-append o-path ".lock"))
+               (locked #f)
+               (unlock
+                (lambda ()
+                  (close-port locked)
+                  (delete-file lock))))
+          (let retry ()
+            (if (file-exists? lock)
+              (begin
+                (thread-sleep! .01)
+                (retry))
+              (begin
+                (set! locked
+                  (with-catch false (cut open-file [path: lock create: #t])))
+                (unless locked
+                  (retry)))))
 
-            (unwind-protect
-              (when (or (not (file-exists? o-path))
-                        (not scm-path)
-                        (file-newer? scm-path o-path))
-                (let (gsc-cc-opts (gsc-cc-options static: #f))
-                  (invoke (gerbil-gsc)
-                          ["-obj"
-                           gsc-cc-opts ...
-                           gsc-static-opts ...
-                           c-path])))
-              (unlock)))))
+          (unwind-protect
+            (when (or (not (file-exists? o-path))
+                      (not scm-path)
+                      (file-newer? scm-path o-path))
+              (let (gsc-cc-opts (gsc-cc-options static: #f))
+                (invoke (gerbil-gsc)
+                        ["-obj" "-o" o-path
+                         gsc-cc-opts ...
+                         gsc-static-opts ...
+                         c-path])))
+            (unlock))))
 
       (with-driver-mutex (create-directory* (path-directory output-bin)))
       (with-output-to-scheme-file output-scm
@@ -286,9 +303,12 @@ namespace: gxc
                          src-deps-scm ...
                          src-bin-scm
                          output-scm])
-                (for-each compile-obj
+                (for-each (lambda (scm-path c-path)
+                            (compile-obj scm-path c-path
+                                         (compile-output-dir
+                                          (replace-extension c-path ".o"))))
                           [src-deps-scm ... src-bin-scm output-scm #f]
-                          [src-deps-c ...   src-bin-c   output-c   output_-c])
+                          [src-deps-c ... src-bin-c output-c output_-c])
                 (invoke (gerbil-gcc)
                         ["-w" "-o" output-bin
                          src-deps-o ...
@@ -307,7 +327,7 @@ namespace: gxc
 
   (let* ((output-bin (compile-exe-output-file ctx opts))
          (output-scm (string-append output-bin "__exe.scm")))
-    (compile-stub output-scm output-bin)))
+    (compile-stub (compile-output-dir output-scm) output-bin)))
 
 (def (compile-executable-module/full-program-optimization ctx opts)
   (def (reset-declare)
@@ -435,7 +455,7 @@ namespace: gxc
 
   (let* ((output-bin (compile-exe-output-file ctx opts))
          (output-scm (string-append output-bin "__exe.scm")))
-    (compile-stub output-scm output-bin)))
+    (compile-stub (compile-output-dir output-scm) output-bin)))
 
 (def (find-export-binding ctx id)
   (cond
@@ -933,9 +953,15 @@ namespace: gxc
              stdout-redirection: (stdout-redirection #f)
              stderr-redirection: (stderr-redirection #f))
   (verbose "invoke " [program . args])
-  (let* ((proc (open-process [path: program arguments: args
+  (let* ((output-dir (current-compile-output-dir))
+         (env (and output-dir
+                   [(##os-environ) ...
+                    (string-append "GAMBIT_OUTPUT_PREFIX="
+                                   output-dir)]))
+         (proc (open-process [path: program arguments: args
                                     stdout-redirection: stdout-redirection
-                                    stderr-redirection: stderr-redirection]))
+                                    stderr-redirection: stderr-redirection
+                                    environment: env]))
          (output (and (or stdout-redirection stderr-redirection)
                       (read-line proc #f))))
     (let (status (process-status proc))


### PR DESCRIPTION
This patch force Gerbil (and Gambit) to write intermediate compilation objects into `(current-compile-output-dir)`. Motivated by this error:

> Some more context could be found on Gerbil support channel [here](https://matrix.to/#/!IDWhkcxckGboGwYSUp:gitter.im/$5Ci1bHxV3TnwWZpt7ug64_7L6C3R_DNz-4vMjGcm8dQ?via=gitter.im&via=matrix.org&via=benkard.de). 

```
$ gxc -static -exe -o app app.ss                                                                   
/nix/store/i2fr4hsl5bs704bp8kihxdxbnvcsm3h3-gerbil-cli/gerbil/lib/static/cli__cli.scm:
*** ERROR IN c#targ-start-dump -- Read-only file system
(open-output-file "/nix/store/i2fr4hsl5bs704bp8kihxdxbnvcsm3h3-gerbil-cli/gerbil/lib/static/cli__cli.c")
#f*** ERROR IN gxc#compile-executable-module/separate -- 
*** ERROR IN ?
--- Syntax Error at (compile-exe app.ss): Compilation error; process exit with nonzero status
... form:   ("/nix/store/58g7klswv88zp6d3kmdzyk67rf3x5035-gerbil-gerbil-unstable-2024-05-11/gerbil/v0.18.1/bin/gsc"
             "-link"
             "/nix/store/58g7klswv88zp6d3kmdzyk67rf3x5035-gerbil-gerbil-unstable-2024-05-11/gerbil/v0.18.1/lib/static/gerbil__runtime__gambit.c"
             ...
$ echo $GERBIL_LOADPATH
/nix/store/i2fr4hsl5bs704bp8kihxdxbnvcsm3h3-gerbil-cli/gerbil/lib
```

Quick demonstration of the effect this patch has on `gxc`:

```console
 ~/projects/src/github.com/mighty-gerbils/gerbil  λ  ls -la ~/.gerbil                                                 ✖ 2
"/home/user/.gerbil": No such file or directory (os error 2)
 ~/projects/src/github.com/mighty-gerbils/gerbil  λ  cat hello.ss
(export main)
(def (main . args)
     (displayln "hello"))

 ~/projects/src/github.com/mighty-gerbils/gerbil  λ  gxc -exe -static hello.ss                                        (5s 732ms)
/home/user/.gerbil/lib/static/schemered__hello.scm:
/home/user/.gerbil/lib/hello__exe.scm:
...

 ~/projects/src/github.com/mighty-gerbils/gerbil  λ  ./hello                                                          (1s 739ms)
hello
 ~/projects/src/github.com/mighty-gerbils/gerbil  λ  tree ~/.gerbil/lib
/home/user/.gerbil/lib
├── hello__exe.scm
├── schemered
│   ├── hello~0.scm
│   ├── hello.scm
│   └── hello.ssi
└── static
    ├── schemered__hello.c
    ├── schemered__hello.o
    └── schemered__hello.scm

3 directories, 7 files
 ~/projects/src/github.com/mighty-gerbils/gerbil  λ  ls -la hello*
.rwxr-xr-x 15M user 20 Jul 00:57 hello
.rw-r--r--  59 user 20 Jul 00:57 hello.ss
```

This patch depends on changes in Gambit (but I am not sure, maybe  we could improve it, so we don't need to change any thing in Gambit?) https://github.com/gambit/gambit/pull/914