### PR TITLE
fix openssl linking for builds with `--disable-shared`

### DIFF
--- a/src/build/build-bach.ss
+++ b/src/build/build-bach.ss
@@ -125,13 +125,15 @@
           ["-e" include-gambit-sharp]))
        (output-bin
         (path-expand "gerbil" gerbil-bindir))
-       (gerbil-shared?
-        (member "--enable-shared" (string-split (configure-command-string) #\')))
+       (configure-flags (string-split (configure-command-string) #\'))
+       (gerbil-shared? (member "--enable-shared" configure-flags))
+       (enable-openssl? (member "--enable-openssl" configure-flags))
        (rpath-options
         (if gerbil-shared?
           [(string-append (cond-expand (darwin "-Wl,-rpath,") (else "-Wl,-rpath="))
 		                  gambit-libdir)]
-          [])))
+          []))
+       (extra-ld-options (if enable-openssl? ["-lssl" "-lcrypto"] [])))
   (displayln "... link " output-bin)
   (invoke (gerbil-gsc)
           ["-link" "-o" bach-link-c
@@ -153,7 +155,8 @@
            bach-main-o
            bach-link-o
            "-L" gerbil-libdir "-lgambit"
-           default-ld-options ...])
+           default-ld-options ...
+           extra-ld-options ...])
   ;; clean up
   (delete-file bach-main-scm)
   (delete-file bach-link-c)

--- a/src/std/build-spec.ss
+++ b/src/std/build-spec.ss
@@ -208,18 +208,14 @@
         '())
     ;; :std/net
     "net/address"
-    ,(cond-expand
-      (darwin
-       `(gxc: "net/ssl/libssl"
+    (gxc: "net/ssl/libssl"
 	      "-cc-options" ,(cppflags "libssl" "")
 	      "-ld-options" ,(apply append-options
 			               (ldflags "libssl" "-lssl")
 			               (ldflags "libcrypto" "-lcrypto")
                            (if (enable-shared?)
                              [(string-append "-L" (gerbil-libdir)) "-lgambit"]
-                             []))))
-      (else `(gxc: "net/ssl/libssl"
-		   "-ld-options" ,(ldflags "libssl" "-lssl"))))
+                             [])))
     "net/ssl/error"
     "net/ssl/interface"
     "net/ssl/socket"


### PR DESCRIPTION
I have discovered there are some undefined references to OpenSSL when building with `--disable-shared`. Probably because linker flags `-lssl -lcrypto` is missing when building with `--disable-shared`. If I disable OpenSSL with configure flag then it builds fine, but fails at runtime when importing modules like `:std/net/request` (which is expected), while things like `:std/db/sqlite` is working (so proooobably my build environment is fine). 

Here is an error I've got while making [my Nix builder](https://github.com/corpix/gerbil-nix/blob/master/gerbil-builder.nix):

<summary><details>

```console
...
gerbil> ... execute compile job (compile /build/source/build/lib/static/gerbil__compiler__optimize-ann.c)
gerbil> ... execute compile job (compile /build/source/build/lib/static/gerbil__compiler__optimize-call.c)
gerbil> ... execute compile job (compile /build/source/build/lib/static/gerbil__compiler__optimize.c)
gerbil> ... execute compile job (compile /build/source/build/lib/static/gerbil__compiler__driver.c)
gerbil> ... execute compile job (compile /build/source/build/lib/static/gerbil__compiler__ssxi.c)
gerbil> ... execute compile job (compile /build/source/build/lib/static/gerbil__compiler.c)
gerbil> ... execute compile job (compile /build/source/build/lib/static/gerbil__main.c)
gerbil> ... execute compile job (compile /build/source/build/lib/gerbil-link.c)
gerbil> ... build /build/source/build/bin/gerbil
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: /build/source/build/lib/libgambit.a(os_base.o): in function `___os_err_code_to_string':
gerbil> os_base.c:(.text+0xcb6): undefined reference to `ERR_error_string'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: /build/source/build/lib/libgambit.a(os_io.o): in function `___release_rc_tls_context':
gerbil> os_io.c:(.text+0x734): undefined reference to `SSL_CTX_free'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: /build/source/build/lib/libgambit.a(os_io.o): in function `try_connect':
gerbil> os_io.c:(.text+0x7a1): undefined reference to `SSL_connect'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: /build/source/build/lib/libgambit.a(os_io.o): in function `___device_tcp_client_write_raw_virt':
gerbil> os_io.c:(.text+0x7f3): undefined reference to `ERR_clear_error'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x807): undefined reference to `SSL_write'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x82f): undefined reference to `SSL_get_shutdown'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x846): undefined reference to `SSL_get_error'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x883): undefined reference to `SSL_get_error'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x901): undefined reference to `ERR_clear_error'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x90a): undefined reference to `SSL_shutdown'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: /build/source/build/lib/libgambit.a(os_io.o): in function `___device_tcp_client_read_raw_virt':
gerbil> os_io.c:(.text+0x973): undefined reference to `ERR_clear_error'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x987): undefined reference to `SSL_read'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x9d7): undefined reference to `SSL_get_shutdown'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x9ee): undefined reference to `SSL_get_error'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0xa23): undefined reference to `SSL_get_error'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0xaa1): undefined reference to `ERR_clear_error'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0xaaa): undefined reference to `SSL_shutdown'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: /build/source/build/lib/libgambit.a(os_io.o): in function `___device_tcp_client_release_raw_virt':
gerbil> os_io.c:(.text+0xace): undefined reference to `SSL_free'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: /build/source/build/lib/libgambit.a(os_io.o): in function `___device_tcp_client_close_raw_virt':
gerbil> os_io.c:(.text+0xb1e): undefined reference to `SSL_is_init_finished'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0xb32): undefined reference to `ERR_clear_error'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0xb3b): undefined reference to `SSL_shutdown'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0xb55): undefined reference to `SSL_get_error'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0xb6d): undefined reference to `SSL_free'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: /build/source/build/lib/libgambit.a(os_io.o): in function `___os_make_tls_context':
gerbil> os_io.c:(.text+0x2621): undefined reference to `OPENSSL_init_ssl'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x262e): undefined reference to `OpenSSL_version_num'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2659): undefined reference to `RAND_status'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2779): undefined reference to `TLS_server_method'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2781): undefined reference to `SSL_CTX_new'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x27a5): undefined reference to `SSL_CTX_set_session_id_context'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x27cc): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2821): undefined reference to `TLS_client_method'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2829): undefined reference to `SSL_CTX_new'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x284d): undefined reference to `SSL_CTX_set_session_id_context'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2874): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x28e5): undefined reference to `SSL_CTX_set_session_id_context'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x28fe): undefined reference to `SSL_CTX_set_session_id_context'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x291e): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2969): undefined reference to `PEM_read_DHparams'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x298a): undefined reference to `DH_check'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x29aa): undefined reference to `DH_set0_pqg'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x29bd): undefined reference to `SSL_CTX_ctrl'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x29c8): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x29d3): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x29f6): undefined reference to `SSL_CTX_use_certificate_file'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2a10): undefined reference to `SSL_CTX_use_PrivateKey_file'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2a21): undefined reference to `SSL_CTX_check_private_key'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2a3e): undefined reference to `SSL_CTX_ctrl'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2a47): undefined reference to `SSL_CTX_set_default_verify_paths'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2a57): undefined reference to `SSL_CTX_set_verify'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2aa7): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2ac0): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2ad9): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2af2): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2b23): undefined reference to `SSL_load_client_CA_file'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2b38): undefined reference to `SSL_CTX_set_client_CA_list'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2b48): undefined reference to `SSL_CTX_set_verify'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2b66): undefined reference to `SSL_CTX_use_certificate_file'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2b80): undefined reference to `SSL_CTX_use_PrivateKey_file'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2b91): undefined reference to `SSL_CTX_check_private_key'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2bae): undefined reference to `SSL_CTX_ctrl'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2bbf): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2bd4): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2bf0): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2c05): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2c23): undefined reference to `SSL_CTX_set_options'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: /build/source/build/lib/libgambit.a(os_io.o):os_io.c:(.text+0x2c3c): more undefined references to `SSL_CTX_set_options' follow
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: /build/source/build/lib/libgambit.a(os_io.o): in function `___os_make_tls_context':
gerbil> os_io.c:(.text+0x2c6c): undefined reference to `DH_new'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2c87): undefined reference to `BN_bin2bn'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2ca2): undefined reference to `BN_bin2bn'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2cbf): undefined reference to `BN_free'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2cc9): undefined reference to `BN_free'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2cd1): undefined reference to `DH_free'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: /build/source/build/lib/libgambit.a(os_io.o): in function `___device_tcp_client_setup_from_sockaddr':
gerbil> os_io.c:(.text+0x2f82): undefined reference to `SSL_new'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2f97): undefined reference to `SSL_set_fd'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x2fb7): undefined reference to `SSL_ctrl'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: /build/source/build/lib/libgambit.a(os_io.o): in function `___device_tcp_server_read':
gerbil> os_io.c:(.text+0x31d0): undefined reference to `SSL_new'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x31e4): undefined reference to `SSL_set_fd'
gerbil> /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x31f1): undefined reference to `SSL_accept'
gerbil> collect2: error: ld returned 1 exit status
gerbil> *** ERROR IN "build/build-bach.ss"@149.3-156.36 --
gerbil> *** ERROR IN ? [Error]: process exited abnormally
gerbil> --- irritants: "gcc" 256
gerbil> --- continuation backtrace:
gerbil> [0] error
gerbil> [1] (interaction)                                                                      "build/build-bach.ss"@149:3-156:36                                                      (invoke (gerbil-gcc) (cons "-o" (cons #:output-bin132 (foldr cons (foldr cons...
gerbil> [2] ##load
gerbil> [3] ##load
gerbil> [4] ##main
gerbil>    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━ build/build-bach.ss ━━━━━━━━━━━━━━━━━━━━━━━━━━━
gerbil>    ┃⋯
gerbil> 148┃  (displayln "... build " output-bin)
gerbil> 149┃  (invoke (gerbil-gcc)                                                     
gerbil> 150┃          ["-o" output-bin                                                 
gerbil> 151┃           rpath-options ...                                               
gerbil>    ┃⋯                                                                          
gerbil> 154┃           bach-link-o                                                     
gerbil> 155┃           "-L" gerbil-libdir "-lgambit"                                   
gerbil> 156┃           default-ld-options ...])                                        
gerbil> 157┃  ;; clean up
gerbil>    ┃⋯
gerbil> *** ERROR; build failed
error: builder for '/nix/store/diwpq9a9r8cdnf1xc4343gmqvig9dpip-gerbil-0.18.1.drv' failed with exit code 70;
       last 25 log lines:
       > /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x31e4): undefined reference to `SSL_set_fd'
       > /nix/store/bgcaxhhxswzvmxjbbgvvaximm5hwghz1-binutils-2.41/bin/ld: os_io.c:(.text+0x31f1): undefined reference to `SSL_accept'
       > collect2: error: ld returned 1 exit status
       > *** ERROR IN "build/build-bach.ss"@149.3-156.36 --
       > *** ERROR IN ? [Error]: process exited abnormally
       > --- irritants: "gcc" 256
       > --- continuation backtrace:
       > [0] error
       > [1] (interaction)                                                                      "build/build-bach.ss"@149:3-156:36                                                      (invoke (gerbil-gcc) (cons "-o" (cons #:output-bin132 (foldr cons (foldr cons...
       > [2] ##load
       > [3] ##load
       > [4] ##main
       >    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━ build/build-bach.ss ━━━━━━━━━━━━━━━━━━━━━━━━━━━
       >    ┃⋯
       > 148┃  (displayln "... build " output-bin)
       > 149┃  (invoke (gerbil-gcc)                                                     
       > 150┃          ["-o" output-bin                                                 
       > 151┃           rpath-options ...                                               
       >    ┃⋯                                                                          
       > 154┃           bach-link-o                                                     
       > 155┃           "-L" gerbil-libdir "-lgambit"                                   
       > 156┃           default-ld-options ...])                                        
       > 157┃  ;; clean up
       >    ┃⋯
       > *** ERROR; build failed
...
```

</details></summary>

Not sure about `cond-expand`, why it was only for `darwin`?