### PR TITLE
Fix help after change in display-build-manifest

### DIFF
--- a/src/std/cli/multicall.ss
+++ b/src/std/cli/multicall.ss
@@ -55,7 +55,8 @@
 (define-entry-point (help (command #f))
   (help: "Print help about available commands"
    getopt: [(optional-argument 'command help: "subcommand for which to display help")])
-  (displayln (display-build-manifest (build-manifest/head)))
+  (display-build-manifest (build-manifest/head))
+  (newline)
   (def gopt (apply getopt (entry-points-getopt-spec)))
   (def program (current-program-string (cdr (current-program))))
   (if command


### PR DESCRIPTION
display-build-manifest now always want a port, and to get the string one must use build-manifest-string. So use display-build-manifest then newline.