### PR TITLE
s/##vector-/##values-/g where needed

### DIFF
--- a/src/gerbil/compiler/compile.ss
+++ b/src/gerbil/compiler/compile.ss
@@ -531,7 +531,7 @@ namespace: gxc
 
 (def (generate-runtime-values-count var)
   (def (generate-inline)
-    ['if ['##values? var] ['##vector-length var] 1])
+    ['if ['##values? var] ['##values-length var] 1])
 
   ;; see gambit#422
   (with-inline-unsafe-primitives (generate-inline)
@@ -542,8 +542,8 @@ namespace: gxc
 (def (generate-runtime-values-ref var i rest)
   (def (generate-inline)
     (if (and (fx= i 0) (not (stx-pair? rest)))
-      ['if ['##values? var] ['##vector-ref var 0] var]
-      ['##vector-ref var i]))
+      ['if ['##values? var] ['##values-ref var 0] var]
+      ['##values-ref var i]))
 
   ;; see gambit#422
   (with-inline-unsafe-primitives (generate-inline)
@@ -555,22 +555,22 @@ namespace: gxc
   (cond
    ((fx= i 0)
     (with-inline-unsafe-primitives
-        ['if ['##values? var] ['##vector->list var] ['list var]]
+        ['if ['##values? var] ['##values->list var] ['list var]]
       ['let []
         '(declare (not safe))
-        ['if ['##values? var] ['##vector->list var] ['list var]]]))
+        ['if ['##values? var] ['##values->list var] ['list var]]]))
    ((fx= i 1)
     (with-inline-unsafe-primitives
-        ['if ['##values? var] ['##cdr ['##vector->list var]] '(quote ())]
+        ['if ['##values? var] ['##cdr ['##values->list var]] '(quote ())]
       ['let []
         '(declare (not safe))
-        ['if ['##values? var] ['##cdr ['##vector->list var]] '(quote ())]]))
+        ['if ['##values? var] ['##cdr ['##values->list var]] '(quote ())]]))
    (else
     (with-inline-unsafe-primitives
-        ['##list-tail ['##vector->list var] i]
+        ['##list-tail ['##values->list var] i]
       ['let []
         '(declare (not safe))
-        ['##list-tail ['##vector->list var] i]]))))
+        ['##list-tail ['##values->list var] i]]))))
 
 (def (generate-runtime-lambda% self stx)
   (ast-case stx ()

--- a/src/gerbil/runtime/eval.ss
+++ b/src/gerbil/runtime/eval.ss
@@ -53,7 +53,7 @@ namespace: #f
       (error (if (fx< count k)
                "Too few values for context"
                "Too many values for context")
-        (if (##values? obj) (##vector->list obj) obj)
+        (if (##values? obj) (##values->list obj) obj)
         k))))
 
 (def (__compile stx)
@@ -114,7 +114,7 @@ namespace: #f
                 (lambda (id k)
                   (and (__AST-e id)
                        (__SRC
-                        `(define ,(__SRC id) (##vector-ref ,tmp ,k))
+                        `(define ,(__SRC id) (##values-ref ,tmp ,k))
                         stx)))
                 ids (iota len)))
            stx)))))))
@@ -263,7 +263,7 @@ namespace: #f
              (foldr (lambda (hd r)
                       (match hd
                         ([id . k]
-                         (cons `(,id (##vector-ref ,tmp ,k)) r))))
+                         (cons `(,id (##values-ref ,tmp ,k)) r))))
                     bind init)))
         (else
          (__SRC
@@ -337,7 +337,7 @@ namespace: #f
              (foldr (lambda (hd r)
                       (match hd
                         ([id . k]
-                         (cons `(set! ,id (##vector-ref ,tmp ,k)) r))))
+                         (cons `(set! ,id (##values-ref ,tmp ,k)) r))))
                     bind init)))
         (else
          (__SRC
@@ -416,7 +416,7 @@ namespace: #f
                               (match hd
                                 ([id . k]
                                  (__SRC
-                                  `(set! ,id (##vector-ref ,tmp ,k))
+                                  `(set! ,id (##values-ref ,tmp ,k))
                                   stx))))
                             init))
                   stx)


### PR DESCRIPTION
This is for the universal backend where not everything is a vector.