### PR TITLE
Fix docker packages names

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN case ${distro} in \
     eval yum install -y ${packages} \
     ;; \
     fedora) \
-    yum update -y && yum groupinstall -y 'Development Tools' && \
+    yum update -y && yum group install -y development-tools && \
     eval yum install -y ${packages} \
     ;; \
     debian|ubuntu) \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
-.PHONY: alpine amazonlinux debian ubuntu fedora ubuntu-current-jedi final
+.PHONY: alpine debian ubuntu fedora ubuntu-current-jedi final
 
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 cores := $(shell nproc)
@@ -153,20 +153,6 @@ gerbil:
 	-t final $(ROOT_DIR)
 	docker tag final gerbil/gerbil:$(arch)-$(BRANCH)
 
-amazonlinux:
-	docker build --target final \
-	--rm=true --no-cache \
-	--build-arg branch="$(BRANCH)" \
-	--build-arg configure_args="--enable-march=" \
-	--build-arg cores=$(cores) \
-	--build-arg distro="amazonlinux" \
-	--build-arg packages="$(amazon_packages)" \
-	--build-arg repo="$(REPO)" \
-	--build-arg shared="no" \
-	--build-arg with_db="YES" \
-	-t final $(ROOT_DIR)
-	docker tag final gerbil/amazonlinux:$(arch)-$(BRANCH)
-
 centos:
 	docker build --target final \
 	--rm=true --no-cache \
@@ -246,26 +232,16 @@ package-fedora:
     -d zlib-devel -d zlib-static -d openssl-devel -d sqlite-devel \
 	--description 'Gerbil Scheme Package' /opt/gerbil"
 
-package-amazonlinux:
-	docker run -v $(ROOT_DIR):/src:z -t gerbil/amazonlinux:$(arch)-$(BRANCH) \
-	bash -c "amazon-linux-extras install -y ruby2.6 && \
-	yum install -y ruby-devel rubygems rpm-build && \
-	gem install fpm && \
-	fpm -s dir -p /src/ -t rpm \
-	-n gerbil-$(BRANCH).amazonlinux \
-	--description 'Gerbil Package' /opt/gerbil"
-
 packages: package-ubuntu package-fedora
 
 push-all:
 	docker push gerbil/alpine
 	docker push gerbil/ubuntu
 	docker push gerbil/fedora
-	docker push gerbil/amazonlinux
 
 manifest:
 	docker manifest create gerbil/alpine:latest --amend gerbil/alpine:aarch64 --amend gerbil/alpine:x86_64
 
-all: alpine amazonlinux fedora ubuntu
+all: alpine fedora ubuntu
 
 docker: ubuntu

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -242,8 +242,8 @@ package-fedora:
 	bash -c "yum install -y rubygems ruby-devel rpm-build && \
 	gem install fpm && \
 	fpm -f -s dir -p /src/ -t rpm \
-	-n gerbil-$(BRANCH).fedora \
-    -d zlib-devel -d zlib-static -d openssl-devel -d sqlite-devel -v $(TAG) \
+	-n gerbil-$(BRANCH).fedora -v $(TAG} \
+    -d zlib-devel -d zlib-static -d openssl-devel -d sqlite-devel \
 	--description 'Gerbil Scheme Package' /opt/gerbil"
 
 package-amazonlinux:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -243,7 +243,7 @@ package-fedora:
 	gem install fpm && \
 	fpm -f -s dir -p /src/ -t rpm \
 	-n gerbil-$(BRANCH).fedora \
-        -d zlib-devel -d zlib-static -d openssl-devel -d sqlite-devel \
+    -d zlib-devel -d zlib-static -d openssl-devel -d sqlite-devel -v $(TAG) \
 	--description 'Gerbil Scheme Package' /opt/gerbil"
 
 package-amazonlinux:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -222,7 +222,7 @@ ubuntu-current-jedi:
 package-ubuntu:
 	docker run -v $(ROOT_DIR):/src:z -t gerbil/ubuntu:$(arch)-$(BRANCH) \
 	bash -c "gem install fpm && \
-	fpm -f -s dir -p /src/ -t deb -n gerbil-$(BRANCH).ubuntu \
+	fpm -f -s dir -p /src/ -t deb -n gerbil-scheme.ubuntu -v $(TAG) \
 	-d libsqlite3-dev -d libssl-dev \
 	--description 'Gerbil Scheme Package' /opt/gerbil"
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -242,7 +242,7 @@ package-fedora:
 	bash -c "yum install -y rubygems ruby-devel rpm-build && \
 	gem install fpm && \
 	fpm -f -s dir -p /src/ -t rpm \
-	-n gerbil-$(BRANCH).fedora -v $(TAG} \
+	-n gerbil-$(BRANCH).fedora -v $(TAG) \
     -d zlib-devel -d zlib-static -d openssl-devel -d sqlite-devel \
 	--description 'Gerbil Scheme Package' /opt/gerbil"
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,11 +9,14 @@ ifeq ($(BRANCH),)
 BRANCH := $(shell git branch --show-current)
 endif
 
+TAG := $(shell git describe --tags)
+
 ifeq ($(REPO),)
 REPO := $(shell git remote get-url $(shell git rev-parse --abbrev-ref --symbolic-full-name @{u}|cut -f1 -d/)|cut -f2 -d:)
 endif
 
 cores := $(shell nproc)
+
 $(info the branch is $(BRANCH) and the repo is $(REPO) cores are: $(cores))
 
 alpine_packages := autoconf \
@@ -118,6 +121,10 @@ debian_packages := autoconf \
                    rubygems \
                    texinfo \
                    zlib1g-dev
+
+debug:
+	$(info the branch is $(BRANCH) and the repo is $(REPO) cores are: $(cores))
+
 
 gerbilxx:
 	docker build --target final \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,6 +9,8 @@ ifeq ($(BRANCH),)
 BRANCH := master
 endif
 
+TAG := $(shell git describe --tags)
+
 ifeq ($(REPO),)
 REPO := mighty-gerbils/gerbil
 endif

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,10 +9,8 @@ ifeq ($(BRANCH),)
 BRANCH := $(shell git branch --show-current)
 endif
 
-TAG := $(shell git describe --tags)
-
 ifeq ($(REPO),)
-REPO := mighty-gerbils/gerbil
+REPO := $(shell git remote get-url $(shell git rev-parse --abbrev-ref --symbolic-full-name @{u}|cut -f1 -d/)|cut -f2 -d:)
 endif
 
 cores := $(shell nproc)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,7 +6,7 @@ arch := $(shell uname -m)
 DEFAULT=gerbilxx
 
 ifeq ($(BRANCH),)
-BRANCH := master
+BRANCH := $(shell git branch --show-current)
 endif
 
 TAG := $(shell git describe --tags)


### PR DESCRIPTION
To reflect accurately which version of gerbil is installed. This differs from just using "master".
