### PR TITLE
add imenu to gerbil-mode.el

### DIFF
--- a/etc/gerbil-mode.el
+++ b/etc/gerbil-mode.el
@@ -508,6 +508,20 @@
   (interactive)
   (gerbil-init-keywords)
   (gerbil-init-fontlock)
+  (setq-local imenu-generic-expression
+              `(("Var" ,(rx "(def"
+                            (1+ space)
+                            (group (1+ (or word (syntax symbol)))))
+                 1)
+                ("Func" ,(rx "(def"
+                             (1+ space)
+                             (literal "(")
+                             (group (1+ (or word (syntax symbol)))))
+                 1)
+                ("Structs" ,(rx "(defstruct"
+                                (1+ space)
+                                (group (1+ (or word (syntax symbol)))))
+                 1)))
   (when window-system
     (gerbil-pretty-lambdas)))
 


### PR DESCRIPTION
The default imenu expression from scheme-mode doesn't support "gerbil syntax" very well. Here I have crafted some imenu expressions I use myself that worked for what I need in using gerbil minimally.

There is most likely more changes required before this is in a satisfying state before being merged, but opening this pull request should draw some attention in and decide where to go from here.