### PR TITLE
fix emacs gerbil-mode setup

### DIFF
--- a/etc/gerbil-mode.el
+++ b/etc/gerbil-mode.el
@@ -5,6 +5,7 @@
 ;; Author: Dimitris Vyzovitis <vyzo@hackzen.org>
 ;; URL: https://github.com/mighty-gerbils/gerbil
 ;; Version: 1.0
+;; Package-Requires: ((emacs "27.1"))
 ;; Keywords: gerbil major-mode
 ;;
 ;; This file is not part of GNU Emacs.
@@ -531,15 +532,9 @@
 ;;;###autoload
 (define-derived-mode gerbil-mode scheme-mode
   "Gerbil" "Major mode for Gerbil."
-  (kill-all-local-variables)
-  (use-local-map gerbil-mode-map)
-  (setq mode-name "Gerbil")
-  (setq major-mode 'gerbil-mode)
   (setq scheme-program-name gerbil-program-name)
-  (setq comment-start ";;")
-  (scheme-mode-variables)
-  (gerbil-init)
-  (run-hooks 'gerbil-mode-hook))
+  (setq-local comment-start ";;")
+  (gerbil-init))
 
 ;;;###autoload
 (progn


### PR DESCRIPTION
As per discussion in https://github.com/mighty-gerbils/gerbil/issues/1317 here is a PR with the changes to `gerbil-mode`.

Tested on:
 * Ubuntu 22.04 (server ISO) with Emacs 27.1 that comes with it by default.
 * Arch 6.13.8-arch1-1 with Emacs 30.1

I removed some `use-package` settings:
 * `:ensure nil` - this is the default anyway, if someone has it set globally to `t` they know what they are doing and can adjust accordingly on their own.
 * `:straight nil` - external package, the reasoning above applies.
 * `:defer t` - shouldn't be necessary for autoload modules, but have to admit I am not an expert on this one, so any way you want this is fine with me.

All helper functions are tucked into `:preface` section, it is neat :joy: and it is good for copy-pasting, but no strong feelings on this one...

I also updated the `use-package` setup in the docs and split additional setup in a separate section, so if someone copy-pastes the whole setup they don't unwillingly get opinionated choices on what mode to use for parentheses :laughing:

*Additional notes*

* Docs generation didn't work for me intially, there are old deps in the lock file, so I had to run `npm update`, here is the error:
```
node:internal/crypto/hash:79
  this[kHandle] = new _Hash(algorithm, xofLen, algorithmId, getHashCache());
                  ^

Error: error:0308010C:digital envelope routines::unsupported
```

even after I downgraded to `nodejs v20.19.0`, today I run `v23.9.0`.

 * Also you have `vuepress 1.1.0` which is quite old, the current one in 1.x is `1.9.10`.

 * Anyway, I am on Arch, I live dangerously, I understand not everyone wants that, but as a minimum maybe consider specifying node version in package.json. See [Engines](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#engines).
