### PR TITLE
Make standard S3 library also compatible with Google Cloud Storage

### DIFF
--- a/src/std/net/s3/api.ss
+++ b/src/std/net/s3/api.ss
@@ -226,7 +226,8 @@
 
 (def (s3-parse-xml req)
   (read-xml (request-content req)
-    namespaces: '(("http://s3.amazonaws.com/doc/2006-03-01/" . "s3"))))
+    namespaces: '(("http://s3.amazonaws.com/doc/2006-03-01/" . "s3")
+                  ("http://doc.s3.amazonaws.com/2006-03-01" . "s3"))))
 
 (defrule (s3-response-error? xml)
   (sxml-find xml (sxml-e? 'Error)))

--- a/src/std/net/s3/api.ss
+++ b/src/std/net/s3/api.ss
@@ -239,5 +239,6 @@
       (begin
         (request-close req)
         (raise-s3-error
-          (request-status req)
-          (request-status-text req))))))
+          s3-client::request
+          (request-status-text req)
+          (request-status req))))))

--- a/src/std/net/s3/api.ss
+++ b/src/std/net/s3/api.ss
@@ -193,7 +193,7 @@
              (host (if bucket
                      (string-append bucket "." (s3-client-endpoint self))
                      (s3-client-endpoint self)))
-             (headers [["Host" :: (string-append host ":443")]
+             (headers [["Host" :: host]
                        ["x-amz-date" :: ts]
                        ["x-amz-content-sha256" :: (hex-encode hash)]
                        (if body [["Content-Type" :: content-type]] []) ...

--- a/src/std/net/s3/sigv4-test.ss
+++ b/src/std/net/s3/sigv4-test.ss
@@ -1,0 +1,55 @@
+(export sigv4-test)
+
+(import (only-in :std/test test-suite test-case check)
+        (only-in :std/crypto/digest sha256)
+        (only-in :std/text/hex hex-encode)
+        (only-in "./sigv4" aws4-canonical-request aws4-sign aws4-auth))
+
+(def host "storage.googleapis.com")
+(def uri "/")
+(def date "20250225")
+(def timestamp (string-append date "T052229Z"))
+(def hash (sha256 #u8()))
+(def hex (hex-encode hash))
+(def scope (string-append date "/us/s3"))
+(def access-key "my-access-key")
+(def secret-key "my-secret-key")
+(def headers [["host" :: host] ["x-amz-content-sha256" :: hex] ["x-amz-date" :: timestamp]])
+  
+(def sigv4-test
+  (test-suite "test :std/net/s3/sigv4"
+    (test-case "aws4-auth"
+      (check (aws4-auth
+              scope
+              (aws4-canonical-request verb: 'GET uri: uri query: [] hash: hash headers: headers)
+              timestamp
+              headers
+              secret-key
+              access-key)
+             =>
+             "AWS4-HMAC-SHA256 Credential=my-access-key/20250225/us/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=e11e1b2a37e0448922b3f911e716d028760a807f94f7b5994f58eb3ce3a5bd7f"))
+
+    (test-case "aws4-sign"
+      (check (hex-encode
+              (aws4-sign
+               scope
+               (aws4-canonical-request verb: 'GET uri: uri query: [] hash: hash headers: headers)
+               timestamp
+               secret-key))
+             =>
+             "e11e1b2a37e0448922b3f911e716d028760a807f94f7b5994f58eb3ce3a5bd7f"))
+
+    (test-case "aws4-canonical-request"
+      (check (aws4-canonical-request verb: 'GET uri: uri query: [] hash: hash headers: headers)
+             =>
+             (string-join
+              ["GET"
+               uri
+               ""
+               (string-append "host:" host)
+               (string-append "x-amz-content-sha256:" hex)
+               (string-append "x-amz-date:" timestamp)
+               ""
+               "host;x-amz-content-sha256;x-amz-date"
+               hex]
+              #\newline)))))

--- a/src/std/net/s3/sigv4-test.ss
+++ b/src/std/net/s3/sigv4-test.ss
@@ -3,7 +3,7 @@
 (import (only-in :std/test test-suite test-case check)
         (only-in :std/crypto/digest sha256)
         (only-in :std/text/hex hex-encode)
-        (only-in "./sigv4" aws4-canonical-request aws4-sign aws4-auth))
+        (only-in ./sigv4 aws4-canonical-request aws4-sign aws4-auth))
 
 (def host "storage.googleapis.com")
 (def uri "/")


### PR DESCRIPTION
I experienced some critical errors when trying to use the S3  library with Google Cloud Storage. The library now handles AWS' and Google's S3 API correctly.

I also fixed (what I assume to be) an error reporting mistake in the `with-request-error` procedure

I tried writing tests for `s3-parse-xml`, but I had a pretty rough time trying to artificially create a `request` instance that correctly responds to `(request-content req)` with a  pre-supplied string. Implementing a one-off struct that implements `StreamSocket` seemed excessive. I ultimately gave up, considering how little "novel" functionality exists in `s3-parse-xml`, but I guess we could split the procedure and test "just the XML" part.

Let me know if any additional tests are necessary.