### PR TITLE
Add `exists?` method to `S3Bucket` interface

### DIFF
--- a/doc/reference/std/net/s3.md
+++ b/doc/reference/std/net/s3.md
@@ -92,6 +92,7 @@ The `S3Bucket` interface provides a consistent way to interact with buckets.
 ```scheme
 (interface S3Bucket
   (get  (name :~ string?))
+  (exists? (name :~ string?))
   (put! (name :~ string?)
         (data :~ u8vector?))
   (delete! (name :~ string?))
@@ -106,6 +107,15 @@ The `S3Bucket` interface provides a consistent way to interact with buckets.
 
 `S3Bucket-get` retrieves a object by name. If the object does not exist or the client
 does not have permission to retrieve the object, an `S3Error` is raised.
+
+## S3Bucket-exists?
+
+```scheme
+(S3Bucket-exists? bucket object-name) -> bool
+```
+
+`S3Bucket-exists?` checks if an object with the provided name exists within the
+bucket. It returns `#t` if an object exists and `#f` otherwise.
 
 ## S3Bucket-put!
 

--- a/src/std/net/s3/api.ss
+++ b/src/std/net/s3/api.ss
@@ -130,6 +130,20 @@
              (request-close req)
              data))))
 
+(defmethod {exists? bucket}
+  (lambda (self key)
+    (using ((self :- bucket)
+            (client self.client :- s3-client))
+      (let* ((req {client.request verb: 'HEAD
+                                  bucket: (bucket-name self)
+                                  path: (string-append "/" key)})
+             (code (request-status req)))
+        (if (memq code [200 404])
+          (begin
+            (request-close req)
+            (= code 200))
+          (with-request-error req))))))
+
 (defmethod {put! bucket}
   (lambda (self key data content-type: (content-type "binary/octet-stream"))
     (using ((self :- bucket)

--- a/src/std/net/s3/interface.ss
+++ b/src/std/net/s3/interface.ss
@@ -14,6 +14,7 @@
 ;; TODO return types
 (interface S3Bucket
   (get  (name : :string))
+  (exists? (name : :string))
   (put! (name : :string)
         (data : :u8vector))
   (delete! (name : :string))


### PR DESCRIPTION
This functionality might seem redundant, but there are some pretty severe drawbacks to using existing options:

- Using `S3Bucket-get` works _alright_ as a proxy, especially if the file doesn't exist (mapping the thrown error to `#f`). However, if the file **does** exist, downloading the file to confirm its existence is a waste, especially if the file is large
- Using `S3Bucket-list-objects` can work well, but only if the quantity of objects is small and/or the list of objects rarely change (enabling caching)

I tried to make the method name match existing conventions, but it might create an unfortunate ambiguity: `S3Bucket-exists?` versus `S3-bucket-exists?`. I am open to changing the name if a better suggestion exists