### PR TITLE
Update Gambit to latest v4.9.6-17-gdc315982

### DIFF
--- a/configure
+++ b/configure
@@ -72,7 +72,7 @@ else
   readonly gerbil_version="$(git describe --tags --always)"
 fi
 readonly gerbil_targets=""
-readonly default_gambit_tag=b46d47a805b170d36a671d6bb30aa55af9738c69
+readonly default_gambit_tag=dc315982de002ea299ab4640cb2a896ac65e59e4
 readonly default_gambit_config="--enable-targets=${gerbil_targets} --enable-single-host --enable-dynamic-clib --enable-default-runtime-options=tE8,f8,-8 --enable-trust-c-tco"
 prefix="/opt/gerbil"
 readonly cflags_opt="-foptimize-sibling-calls"


### PR DESCRIPTION
Importantly, re-fixes Gambit #659 (letrec*) with better performance, which is important for Gerbil since we expand internal definitions into letrec*.