### PR TITLE
Atomic promises

### DIFF
--- a/src/gerbil/compiler/method.ss
+++ b/src/gerbil/compiler/method.ss
@@ -76,7 +76,7 @@ namespace: gxc
        #'(begin
            (defclass (klass super ...) slots)
            (def klass-bind-methods!
-             (delay
+             (delay-atomic
                (begin
                  (force super-bind-methods!) ...
                  (bind-method! klass::t 'method implementation) ...))))))
@@ -90,7 +90,7 @@ namespace: gxc
        #'(begin
            (defclass (klass super ...) slots)
            (def klass-bind-methods!
-             (delay
+             (delay-atomic
                (begin
                  (force super-bind-methods!) ...
                  (bind-method! klass::t 'method implementation) ...)))
@@ -109,7 +109,7 @@ namespace: gxc
        #'(begin
            (defclass (klass super ...) slots final: #t)
            (def klass-bind-methods!
-             (delay
+             (delay-atomic
                (begin
                  (force super-bind-methods!) ...
                  (bind-method! klass::t 'method implementation) ...

--- a/src/gerbil/core/runtime.ss
+++ b/src/gerbil/core/runtime.ss
@@ -1517,6 +1517,7 @@ package: gerbil/core
 
     ;; :gerbil/runtime/control
     make-promise
+    make-atomic-promise
     call-with-parameters
     with-unwind-protect
     keyword-dispatch

--- a/src/gerbil/core/sugar.ss
+++ b/src/gerbil/core/sugar.ss
@@ -1038,12 +1038,23 @@ package: gerbil/core
          #'(quote e)
          (generate #'e 0)))))
 
-  (defrules delay ()
+  (defrules delay (quote)
     ((_ datum)
      (stx-datum? #'datum)
      (quote datum))
+    ((_ (quote datum))
+     (quote datum))
     ((_ expr)
      (make-promise (lambda% () expr))))
+
+  (defrules delay-atomic (quote)
+    ((_ datum)
+     (stx-datum? #'datum)
+     (quote datum))
+    ((_ (quote datum))
+     (quote datum))
+    ((_ expr)
+     (make-atomic-promise (lambda% () expr))))
 
   ;; and end with partial lambda
   (defsyntax% (cut stx)

--- a/src/gerbil/expander/module.ss
+++ b/src/gerbil/expander/module.ss
@@ -56,7 +56,7 @@ namespace: gx
               (path (module-context-path ctx))
               (in   (map core-module-export->import
                          (module-context-export ctx)))
-              (e    (delay (eval-module ctx))))
+              (e    (delay-atomic (eval-module ctx))))
           (struct-instance-init! self id (make-hash-table-eq size: (length in))
                                  super #f #f
                                  path in e)
@@ -170,7 +170,7 @@ namespace: gx
                  (core-cons '%#begin body)
                  path ctx [])))
           (set! (&module-context-e ctx)
-            (delay (eval-syntax* body)))
+            (delay-atomic (eval-syntax* body)))
           (set! (&module-context-code ctx)
             body)
           (hash-put! __module-registry path ctx)
@@ -612,7 +612,7 @@ namespace: gx
                 (core-cons '%#begin body)
                 (stx-source stx))))
          (set! (&module-context-e ctx)
-           (delay (eval-syntax* body)))
+           (delay-atomic (eval-syntax* body)))
          (set! (&module-context-code ctx)
            body)
          (core-bind-syntax! id ctx)


### PR DESCRIPTION
Implements an atomic promise primitive and uses it where appropriate (compiler method binding and module evals)

This should hopefully fixing the concurrency gremlins with parallel builds