### PR TITLE
Fix `inconsistant` -> `inconsistent` typo in FFI guide

### DIFF
--- a/doc/guide/ffi.md
+++ b/doc/guide/ffi.md
@@ -228,7 +228,7 @@ typedef struct point {
   int y;
 } coords;
 
-// Consider an inconsistant codebase, where functions may type their
+// Consider an inconsistent codebase, where functions may type their
 // parameters and return values with both `struct point` and the
 // typedef alias `coords`.
 


### PR DESCRIPTION
Line 231 of `doc/guide/ffi.md` has `inconsistant` (extra a) in a code comment.